### PR TITLE
debug.jsonl: bounded rotation (50 MB / keep 3 by default)

### DIFF
--- a/src/util.mts
+++ b/src/util.mts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir, platform, tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
-import { appendFileSync, mkdirSync } from 'node:fs'
+import { appendFileSync, mkdirSync, renameSync, statSync, unlinkSync } from 'node:fs'
 
 export function nowSeconds(): number {
   return Math.floor(Date.now() / 1000)
@@ -46,8 +46,43 @@ export function debugLog(event: string, data: Record<string, unknown> = {}): voi
   const path = resolve(process.env.CLAUDE_CODEX_DEBUG_LOG || join(adapterHome(), 'debug.jsonl'))
   try {
     ensureParent(path)
+    rotateLogIfNeeded(path)
     appendFileSync(path, JSON.stringify({ ts: new Date().toISOString(), pid: process.pid, event, ...(redact(data) as Record<string, unknown>) }) + '\n')
   } catch {}
+}
+
+// Long-running adapter daemons would otherwise grow debug.jsonl until the disk
+// fills. Bound it with a simple `.1`/`.2`/... rotation: when the active log
+// passes `maxBytes`, push it down one slot and start fresh. Bound by `keep`,
+// dropping anything older. Sized envs override; failures swallow because the
+// debug log is best-effort and must never break the main flow.
+export function rotateLogIfNeeded(path: string): void {
+  const maxBytes = numericEnv('CLAUDE_CODEX_DEBUG_LOG_MAX_BYTES', 50 * 1024 * 1024)
+  if (maxBytes <= 0) return
+  const keep = Math.max(1, numericEnv('CLAUDE_CODEX_DEBUG_LOG_KEEP', 3))
+  let size = 0
+  try {
+    size = statSync(path).size
+  } catch {
+    return // file does not exist yet — nothing to rotate
+  }
+  if (size < maxBytes) return
+  // Drop the oldest slot if it would push us past `keep`.
+  const oldest = `${path}.${keep}`
+  try { unlinkSync(oldest) } catch {}
+  // Shift `.k-1` → `.k`, `.k-2` → `.k-1`, …, `.1` → `.2`.
+  for (let i = keep - 1; i >= 1; i -= 1) {
+    try { renameSync(`${path}.${i}`, `${path}.${i + 1}`) } catch {}
+  }
+  // Move the active log to `.1`. The next appendFileSync recreates it.
+  try { renameSync(path, `${path}.1`) } catch {}
+}
+
+function numericEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
 }
 
 export function platformFamily(): string {

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -889,6 +889,38 @@ test('thread/start with ephemeral=true is hidden from thread/list and surfaces t
   }
 })
 
+test('debug.jsonl rotates once it crosses CLAUDE_CODEX_DEBUG_LOG_MAX_BYTES', async () => {
+  const util = await import(resolve('dist/src/util.mjs'))
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-rotate-'))
+  const logPath = join(home, 'debug.jsonl')
+  const prevPath = process.env.CLAUDE_CODEX_DEBUG_LOG
+  const prevMax = process.env.CLAUDE_CODEX_DEBUG_LOG_MAX_BYTES
+  const prevKeep = process.env.CLAUDE_CODEX_DEBUG_LOG_KEEP
+  process.env.CLAUDE_CODEX_DEBUG_LOG = logPath
+  process.env.CLAUDE_CODEX_DEBUG_LOG_MAX_BYTES = '512'
+  process.env.CLAUDE_CODEX_DEBUG_LOG_KEEP = '2'
+  try {
+    // Each line is ~150 bytes; write enough to cross 512 bytes twice.
+    for (let i = 0; i < 30; i += 1) util.debugLog('test.rotate', { i, payload: 'x'.repeat(120) })
+    const fs = await import('node:fs/promises')
+    const entries = await fs.readdir(home)
+    assert.ok(entries.includes('debug.jsonl'), 'active log should exist')
+    assert.ok(entries.includes('debug.jsonl.1'), 'rotation should have produced a .1 slot')
+    // KEEP=2 means at most .1 + .2; .3 must never appear.
+    assert.ok(!entries.includes('debug.jsonl.3'), 'rotation should respect CLAUDE_CODEX_DEBUG_LOG_KEEP')
+    const activeSize = (await fs.stat(logPath)).size
+    assert.ok(activeSize < 512 * 4, 'active log should have been freshly started after rotation')
+  } finally {
+    if (prevPath == null) delete process.env.CLAUDE_CODEX_DEBUG_LOG
+    else process.env.CLAUDE_CODEX_DEBUG_LOG = prevPath
+    if (prevMax == null) delete process.env.CLAUDE_CODEX_DEBUG_LOG_MAX_BYTES
+    else process.env.CLAUDE_CODEX_DEBUG_LOG_MAX_BYTES = prevMax
+    if (prevKeep == null) delete process.env.CLAUDE_CODEX_DEBUG_LOG_KEEP
+    else process.env.CLAUDE_CODEX_DEBUG_LOG_KEEP = prevKeep
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
 test('defaultSocketPath stays within the platform sun_path limit', async () => {
   const util = await import(resolve('dist/src/util.mjs'))
   const prev = process.env.CODEX_HOME


### PR DESCRIPTION
Adapter daemons can stay up for days; \`debug.jsonl\` was append-only and would silently grow until the disk filled. Now \`rotateLogIfNeeded()\` is called before every write: when the active log crosses the threshold we rename it to \`.1\`, shift existing slots, and let \`appendFileSync\` recreate the active file. Oldest slot beyond \`keep\` is unlinked so on-disk footprint is bounded.

**Defaults**: 50 MiB per slot, keep 3 (active + .1 + .2 + .3).

**Overrides**:
- \`CLAUDE_CODEX_DEBUG_LOG_MAX_BYTES\`
- \`CLAUDE_CODEX_DEBUG_LOG_KEEP\`

**Robustness**: all rotation errors are swallowed inside the existing \`try/catch\` so the debug log never breaks the main flow.

**Test**: new \`debug.jsonl rotates once it crosses CLAUDE_CODEX_DEBUG_LOG_MAX_BYTES\` writes 30 padded entries against a 512-byte threshold and asserts the .1 slot appears while .3 does not (KEEP=2), and the active file restarts small after rotation. 32/32 \`node --test\` green.