### PR TITLE
Enumerate MCP server status capabilities

### DIFF
--- a/src/mcp.mts
+++ b/src/mcp.mts
@@ -34,6 +34,74 @@ export function readMcpConfig(): McpConfigSnapshot {
   }
 }
 
+// Cache enumerated server statuses briefly: the App's MCP panel can poll
+// mcpServerStatus/list, and each miss spawns one child process per server.
+let statusCache: { key: string; at: number; data: Array<Record<string, unknown>> } | null = null
+const STATUS_CACHE_MS = 10_000
+
+// mcpServerStatus/list with real tools/resources enumerated from each server.
+// Falls back to the conformant empty shape per server on any error/timeout so a
+// single unreachable server never fails the whole list.
+export async function listMcpServerStatuses(): Promise<Array<Record<string, unknown>>> {
+  const snapshot = readMcpConfig()
+  const names = serverNames(snapshot.sdkValue)
+  const key = JSON.stringify(snapshot.sdkValue ?? null)
+  if (statusCache && statusCache.key === key && Date.now() - statusCache.at < STATUS_CACHE_MS) {
+    return statusCache.data
+  }
+  const data = await Promise.all(names.map((name) => enumerateServerStatus(name)))
+  statusCache = { key, at: Date.now(), data }
+  return data
+}
+
+async function enumerateServerStatus(name: string): Promise<Record<string, unknown>> {
+  const base = listStatusEntry(name)
+  const [tools, resources, resourceTemplates] = await Promise.all([
+    safeMcpList(name, 'tools/list', 'tools'),
+    safeMcpList(name, 'resources/list', 'resources'),
+    safeMcpList(name, 'resources/templates/list', 'resourceTemplates'),
+  ])
+  if (Array.isArray(tools)) base.tools = toolMap(tools)
+  if (Array.isArray(resources)) {
+    base.resources = resources.map((raw) => asRecord(raw)).filter((r) => typeof r.uri === 'string')
+  }
+  if (Array.isArray(resourceTemplates)) {
+    base.resourceTemplates = resourceTemplates
+      .map((raw) => asRecord(raw))
+      .filter((r) => typeof r.uriTemplate === 'string')
+  }
+  return base
+}
+
+function toolMap(tools: unknown[]): Record<string, Record<string, unknown>> {
+  const entries = tools
+    .map((raw) => asRecord(raw))
+    .filter((tool): tool is Record<string, unknown> & { name: string } => {
+      return typeof tool.name === 'string'
+    })
+    .map((tool) => [
+      tool.name,
+      {
+        name: tool.name,
+        ...(typeof tool.title === 'string' ? { title: tool.title } : {}),
+        ...(typeof tool.description === 'string' ? { description: tool.description } : {}),
+        inputSchema: tool.inputSchema ?? {},
+        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+      },
+    ])
+  return Object.fromEntries(entries)
+}
+
+async function safeMcpList(name: string, method: string, key: string): Promise<unknown[] | null> {
+  const result = await runMcpRequest(name, method, {}).then(
+    (value) => asRecord(value),
+    () => null,
+  )
+  if (!result) return null
+  const value = result[key]
+  return Array.isArray(value) ? value : []
+}
+
 export async function callMcpTool(
   serverName: string,
   toolName: string,
@@ -89,6 +157,17 @@ async function runMcpRequest(
   let nextId = 1
   let buffer = ''
   let stderr = ''
+  let spawnError: Error | null = null
+  // Without an error handler a failed spawn (for example ENOENT for a missing
+  // server binary) emits an unhandled error and crashes the adapter.
+  child.on('error', (error) => {
+    spawnError = error
+    for (const wait of pending.values()) wait.reject(error)
+    pending.clear()
+  })
+  // child.stdin can emit EPIPE when spawn fails; the child error above carries
+  // the useful cause, so keep this stream from becoming an unhandled error too.
+  child.stdin.on('error', () => undefined)
   child.stderr.setEncoding('utf8')
   child.stderr.on('data', (chunk) => {
     stderr += String(chunk)
@@ -112,6 +191,7 @@ async function runMcpRequest(
   })
 
   const request = (requestMethod: string, requestParams: unknown): Promise<unknown> => {
+    if (spawnError) return Promise.reject(spawnError)
     const id = nextId++
     child.stdin.write(
       `${JSON.stringify({ jsonrpc: '2.0', id, method: requestMethod, params: requestParams })}\n`,

--- a/src/server.mts
+++ b/src/server.mts
@@ -2,7 +2,7 @@ import { type ChildProcess, execFile, spawn } from 'node:child_process'
 import { type FSWatcher, readFileSync, watch, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
-import { callMcpTool, readMcpConfig, readMcpResource } from './mcp.mjs'
+import { callMcpTool, listMcpServerStatuses, readMcpConfig, readMcpResource } from './mcp.mjs'
 import {
   addedFileDiff,
   asRecord,
@@ -413,7 +413,7 @@ export class CodexClaudeAppServer {
       case 'config/mcpServer/reload':
         return {}
       case 'mcpServerStatus/list':
-        return { data: readMcpConfig().listStatuses, nextCursor: null }
+        return listMcpServerStatuses().then((data) => ({ data, nextCursor: null }))
       case 'mcpServer/resource/read':
         return readMcpResource(
           stringOr(asRecord(params).server, ''),

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3362,6 +3362,38 @@ test('direct MCP stdio resource and tool calls work', async () => {
   }
 })
 
+test('mcpServerStatus/list enumerates tools and resources from the server', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const fixture = resolve('test/fixtures/mcp-stdio-server.mjs')
+  const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      CODEX_HOME: home,
+      CLAUDE_CODEX_MOCK: '1',
+      CLAUDE_CODEX_MCP_SERVERS: JSON.stringify({
+        fixture: { type: 'stdio', command: process.execPath, args: [fixture] },
+      }),
+      NODE_NO_WARNINGS: '1',
+    },
+  })
+  const reader = new JsonLineReader(proc)
+  try {
+    proc.stdin.write(json({ id: 1, method: 'mcpServerStatus/list', params: {} }))
+    const response = await reader.nextResponse(1)
+    const entry = response.result.data[0]
+    assert.equal(entry.name, 'fixture')
+    assert.ok(entry.tools.echo, 'expected the echo tool enumerated into the map')
+    assert.equal(entry.tools.echo.name, 'echo')
+    assert.ok(entry.tools.echo.inputSchema, 'tool must carry its inputSchema')
+    assert.equal(entry.resources[0].uri, 'fixture://resource')
+    assert.ok(['unsupported', 'notLoggedIn', 'bearerToken', 'oAuth'].includes(entry.authStatus))
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
 test('direct MCP HTTP tool calls work', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const httpServer = http.createServer((req, res) => {

--- a/test/fixtures/mcp-stdio-server.mjs
+++ b/test/fixtures/mcp-stdio-server.mjs
@@ -14,6 +14,24 @@ rl.on('line', (line) => {
     })
     return
   }
+  if (request.method === 'tools/list') {
+    respond(request.id, {
+      tools: [
+        {
+          name: 'echo',
+          description: 'Echo back the provided value',
+          inputSchema: { type: 'object', properties: { value: { type: 'string' } } },
+        },
+      ],
+    })
+    return
+  }
+  if (request.method === 'resources/list') {
+    respond(request.id, {
+      resources: [{ uri: 'fixture://resource', name: 'fixture resource', mimeType: 'text/plain' }],
+    })
+    return
+  }
   if (request.method === 'tools/call') {
     respond(request.id, {
       content: [


### PR DESCRIPTION
## Summary
- enumerate MCP `tools/list`, `resources/list`, and `resources/templates/list` for `mcpServerStatus/list`
- keep per-server failures isolated by falling back to the existing schema-correct empty status shape
- add spawn/stdin error handling so unavailable stdio MCP server binaries do not crash the adapter process
- extend the stdio MCP fixture and add a focused protocol test for populated tools/resources

## Test plan
- `PATH="/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm test -- --test-name-pattern "mcpServerStatus/list enumerates tools and resources from the server"`
- `PATH="/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm test`
- `PATH="/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run typecheck`
- `PATH="/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run check`
- `PATH="/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run docs:build`
- `git diff --check`

## Notes
- This intentionally does not include the other dirty protocol slices from the release workspace: skills/hooks, fuzzy search sessions, or `thread/turns/list` itemsView.
- `npm run check` exits 0 but still reports existing Biome warnings in unrelated files; this PR does not attempt the broader lint cleanup.
