### PR TITLE
[codex] Add open-source compliance docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for helping improve Claude Codex Adapter. This root guide is the GitHub
+entry point; the full contributor guide lives in [docs/contributing.md](docs/contributing.md).
+
+## Before you start
+
+- Use Node.js 24 or newer. The adapter relies on stable `node:sqlite`.
+- Install dependencies with `npm install`.
+- Keep changes small and reviewable. Separate runtime/protocol work, docs work,
+  dependency updates, and release planning into different pull requests.
+- Do not commit secrets, local Claude Code session files, OAuth data, API keys,
+  `.env` files, or acceptance-test transcripts.
+
+## Development checks
+
+Run the checks that match your change:
+
+```bash
+npm run typecheck
+npm run check
+npm test
+npm run docs:build
+```
+
+For runtime or protocol changes, include focused tests under `test/` and run the
+full `npm test` suite. For docs-only changes, run `npm run docs:build` and note
+whether any link-checking gap remains.
+
+## Project layout
+
+- `src/adapter.mts` is the CLI and app-server entry point.
+- `src/server.mts` implements the Codex app-server protocol surface.
+- `src/*-runtime.mts` modules implement selectable Claude/Codex backends.
+- `scripts/codex-shim` is the remote `codex` PATH shim.
+- `docs/` is the VitePress documentation site.
+- `test/` contains `node:test` coverage against compiled `dist/` output.
+
+## Pull request expectations
+
+- Keep each PR focused on one behavior or documentation topic.
+- Include a clear test plan in the PR description.
+- Add or update tests for code changes.
+- Avoid broad formatting churn unless the PR is explicitly a formatting/tooling
+  change.
+
+See [docs/contributing.md](docs/contributing.md) for the detailed toolchain and
+coding conventions.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ mkdir -p ~/bin
 cp scripts/codex-shim ~/bin/codex && chmod +x ~/bin/codex
 export PATH="$HOME/bin:$PATH"
 export CLAUDE_CODEX_ADAPTER="$PWD/dist/src/adapter.mjs"
-export ANTHROPIC_API_KEY="..."      # or `claude /login`
+export ANTHROPIC_API_KEY="<your-anthropic-api-key>" # or authenticate with `claude /login`
 ```
+
+Provide credentials only through your local shell or secret manager. Do not
+commit API keys, OAuth/session data, `.env` files, or acceptance-test logs.
 
 Full walkthrough → **[Getting started](https://fuergaosi233.github.io/claude-codex/guide/getting-started)**.
 
@@ -63,6 +66,8 @@ diffs. Backends are pluggable (default in-process Agent SDK, plus `agent-http`,
 | Backends | <https://fuergaosi233.github.io/claude-codex/guide/backends> |
 | Capability matrix | <https://fuergaosi233.github.io/claude-codex/reference/capability-matrix> |
 | Contributing / toolchain | <https://fuergaosi233.github.io/claude-codex/contributing> |
+| Security policy | [SECURITY.md](SECURITY.md) |
+| Safe examples | [examples/](examples/) |
 
 Docs source lives in [`docs/`](docs/) and is published with VitePress. For
 contributors, the repo also ships progressive `AGENTS.md` files (root + `src/` +

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+Claude Codex Adapter is a community project. Security reports are handled on a
+best-effort basis by the maintainers.
+
+## Reporting a vulnerability
+
+If GitHub private vulnerability reporting is available for this repository, use
+that channel for sensitive reports. If private reporting is not available and
+the issue does not expose secrets or exploitable details, open a GitHub issue
+with a minimal, non-sensitive summary and ask for a private coordination path.
+
+Do not post API keys, OAuth session data, local credential files, private host
+names, or reproducible exploit payloads in public issues, pull requests, logs,
+or screenshots.
+
+## Secret handling
+
+This project should not contain user credentials. Keep these out of git:
+
+- `ANTHROPIC_API_KEY`, provider API keys, bearer tokens, and OAuth refresh data.
+- Claude Code login/session files, including local account state under user
+  home directories.
+- `.env`, shell history, copied `~/.zshenv` snippets with real values, and
+  acceptance-test transcripts that include private paths or tokens.
+- Private proxy URLs, internal hostnames, or subscription/account-sharing
+  details.
+
+Documentation examples use placeholders such as
+`ANTHROPIC_API_KEY="<your-anthropic-api-key>"`. Replace them only in your local
+shell or secret manager. Do not commit the resolved values.
+
+## Authentication boundary
+
+The adapter delegates Claude authentication to Claude Code / the Anthropic SDK
+environment. Users may authenticate locally with their own API key, OAuth login,
+or supported cloud-provider configuration. The adapter should not collect,
+persist, print, or redistribute those credentials.
+
+For tests that need real Claude access, run them only in an environment where
+the required credentials are already provided by the user. Use
+`CLAUDE_CODEX_MOCK=1` for protocol tests that do not require live credentials.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -84,4 +84,4 @@ export CLAUDE_CODEX_NODE="/absolute/path/to/node"
 | `CLAUDE_CODEX_AUTO_WORKTREE` / `_WORKTREE_ROOT` | Per-thread worktree isolation. |
 | `CLAUDE_CODEX_IDLE_EXIT_MS` | Daemon idle shutdown. |
 | `CLAUDE_CODEX_MOCK` | Run the protocol without Claude credentials. |
-| `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` | Claude auth / reverse proxy. |
+| `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` | Claude auth / custom endpoint configuration. Keep real values out of git. |

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -17,21 +17,24 @@ so non-interactive SSH sees them too:
 
 ```bash
 export PATH="$HOME/bin:$PATH"
-export ANTHROPIC_API_KEY="..."                    # or sign in with `claude /login`
+export ANTHROPIC_API_KEY="<your-anthropic-api-key>" # or sign in with `claude /login`
 export CLAUDE_CODEX_ADAPTER="/opt/claude-codex-adapter/dist/src/adapter.mjs"
 export CLAUDE_CODEX_NODE="/absolute/path/to/node" # optional
 export CODEX_REAL="/usr/local/bin/codex.real"     # optional native-Codex fallback
-# export ANTHROPIC_BASE_URL="https://your-anthropic-reverse-proxy.example"  # if api.anthropic.com is region-blocked
 ```
+
+Keep credentials in the host environment or a secret manager. Do not commit
+real API keys, OAuth/session state, `.env` files, copied shell snippets with
+resolved secrets, or private infrastructure URLs.
 
 Codex App keeps using its native SSH flow: it probes `codex --version`, starts
 `codex app-server --listen unix://`, then connects via `codex app-server proxy`.
 The shim routes only those app-server calls to the adapter.
 
-::: tip Reverse proxy
-`ANTHROPIC_BASE_URL` is useful when the host's egress IP is region-blocked from
-`api.anthropic.com` but you still want the same `claude` auth (claude.ai OAuth or
-`ANTHROPIC_API_KEY`).
+::: tip Custom Anthropic endpoints
+If your organization uses a supported custom Anthropic endpoint, configure
+`ANTHROPIC_BASE_URL` in the host environment. Treat the endpoint value as
+deployment configuration and avoid committing private URLs.
 :::
 
 ## Bootstrapping a fresh host (no sudo / Homebrew)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -23,8 +23,10 @@ command-line Codex usage.
 - **Node.js 24+** — the thread store uses `node:sqlite`, which Node 22 hides
   behind `--experimental-sqlite`. The adapter does not pass that flag, so it
   crashes at runtime on 22. Pin a binary with `CLAUDE_CODEX_NODE` if needed.
-- **Claude Code auth** — either `ANTHROPIC_API_KEY` or a `claude /login`
-  (claude.ai OAuth) session. Bedrock/Vertex auth also works.
+- **Claude Code auth** — provide your own `ANTHROPIC_API_KEY`, supported
+  cloud-provider credentials, or a local `claude /login` session. Inject
+  credentials through your shell or secret manager; do not commit keys, OAuth
+  state, `.env` files, or acceptance-test transcripts.
 
 ## Build
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,50 @@
+# Examples
+
+These examples show safe local setup patterns. They intentionally use
+placeholders and do not include real credentials.
+
+## Local shell exports
+
+Use your shell, a local secret manager, or your deployment system to inject
+credentials at runtime. Do not commit `.env` files or resolved secrets.
+
+```bash
+export CLAUDE_CODEX_ADAPTER="$PWD/dist/src/adapter.mjs"
+export CLAUDE_CODEX_NODE="/absolute/path/to/node-24"
+
+# Choose one authentication method managed by your own environment.
+export ANTHROPIC_API_KEY="<your-anthropic-api-key>"
+# or authenticate interactively on the host:
+# claude /login
+```
+
+## Remote shim setup
+
+```bash
+mkdir -p "$HOME/bin"
+cp scripts/codex-shim "$HOME/bin/codex"
+chmod +x "$HOME/bin/codex"
+export PATH="$HOME/bin:$PATH"
+```
+
+After building the adapter, point `CLAUDE_CODEX_ADAPTER` at the compiled entry
+point on that host:
+
+```bash
+npm install
+npm run build
+export CLAUDE_CODEX_ADAPTER="$PWD/dist/src/adapter.mjs"
+```
+
+## Protocol-only local test
+
+Use the mock runtime when you want to test the app-server protocol without live
+Claude credentials:
+
+```bash
+CLAUDE_CODEX_MOCK=1 node dist/src/adapter.mjs app-server --listen ws://127.0.0.1:8788
+```
+
+See [../docs/guide/getting-started.md](../docs/guide/getting-started.md) and
+[../docs/guide/deployment.md](../docs/guide/deployment.md) for the full setup
+guide.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "claude-codex-adapter",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.143",
         "ws": "^8.21.0"

--- a/package.json
+++ b/package.json
@@ -2,10 +2,28 @@
   "name": "claude-codex-adapter",
   "version": "0.1.0",
   "private": true,
+  "description": "Remote-mode adapter that lets the Codex desktop app talk to Claude Code through the Codex app-server protocol.",
+  "license": "MIT",
+  "homepage": "https://fuergaosi233.github.io/claude-codex/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fuergaosi233/claude-codex.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fuergaosi233/claude-codex/issues"
+  },
   "type": "module",
   "bin": {
     "claude-codex-adapter": "dist/src/adapter.mjs"
   },
+  "files": [
+    "dist/",
+    "scripts/",
+    "README.md",
+    "LICENSE",
+    "SECURITY.md",
+    "CONTRIBUTING.md"
+  ],
   "scripts": {
     "dev": "tsx src/adapter.mts",
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Summary
- add root CONTRIBUTING and SECURITY entry points for GitHub visitors
- add safe examples guidance with credential placeholders
- clarify Anthropic credential handling in README and docs
- add minimal package metadata and sync the lockfile root license

## Validation
Ran from a clean detached worktree at this commit, with inherited protocol dirty files absent:
- `git diff --name-only origin/main...HEAD` contained only docs/compliance files plus package metadata
- `git diff --check origin/main...HEAD`
- `rg -n "ANTHROPIC_API_KEY=\"\.\.\.\"|your-anthropic-reverse-proxy|sk-[A-Za-z0-9]|github_pat|BEGIN .*PRIVATE|/Users/Holegots|Holegots" README.md docs CONTRIBUTING.md SECURITY.md examples package.json package-lock.json` returned no matches
- `npm run docs:build`
- `npm run typecheck`
- `npm run check` exited 0; it still reports existing Biome warnings/infos unrelated to this docs-only PR

## Notes
No runtime/protocol files are included in this branch.