### PR TITLE
[codex] Add fuzzy file search sessions

### DIFF
--- a/src/server.mts
+++ b/src/server.mts
@@ -3111,7 +3111,7 @@ export class CodexClaudeAppServer {
     const session = this.fuzzySessions.get(sessionId)
     const roots = session?.roots ?? [process.cwd()]
     const files = await this.fuzzySearchCore(query, roots)
-    if (sessionId && this.fuzzySessions.get(sessionId) === session) {
+    if (session && this.fuzzySessions.get(sessionId) === session) {
       this.notify(peer, {
         method: 'fuzzyFileSearch/sessionUpdated',
         params: { sessionId, query, files },

--- a/src/server.mts
+++ b/src/server.mts
@@ -113,6 +113,7 @@ export class CodexClaudeAppServer {
   >()
   private activePeerByThread = new Map<string, RpcPeer>()
   private activeTurnByThread = new Map<string, string>()
+  private fuzzySessions = new Map<string, { roots: string[] }>()
   private commandSessionAllow = new Map<string, Set<string>>()
   private commandProcesses = new Map<string, ChildProcess>()
   private processHandles = new Map<string, ChildProcess>()
@@ -495,12 +496,12 @@ export class CodexClaudeAppServer {
         return { authMethod: null, authToken: null, requiresOpenaiAuth: false }
       case 'fuzzyFileSearch':
         return this.fuzzyFileSearch(asRecord(params))
-      // Stateful fuzzy-search sessions are not implemented; the one-shot
-      // `fuzzyFileSearch` above already covers the App's file picker needs.
       case 'fuzzyFileSearch/sessionStart':
+        return this.fuzzySessionStart(asRecord(params))
       case 'fuzzyFileSearch/sessionUpdate':
+        return this.fuzzySessionUpdate(peer, asRecord(params))
       case 'fuzzyFileSearch/sessionStop':
-        return {}
+        return this.fuzzySessionStop(peer, asRecord(params))
       default:
         throw new Error(`method not implemented: ${method}`)
     }
@@ -3062,8 +3063,16 @@ export class CodexClaudeAppServer {
   }
 
   private async fuzzyFileSearch(params: Record<string, unknown>): Promise<unknown> {
-    const query = stringOr(params.query, '').toLowerCase()
+    const query = stringOr(params.query, '')
     const roots = Array.isArray(params.roots) ? params.roots.map(String) : [process.cwd()]
+    return { files: await this.fuzzySearchCore(query, roots) }
+  }
+
+  private async fuzzySearchCore(
+    rawQuery: string,
+    roots: string[],
+  ): Promise<Array<Record<string, unknown>>> {
+    const query = rawQuery.toLowerCase()
     const files: Array<Record<string, unknown>> = []
     for (const root of roots) {
       const paths = await listFiles(root)
@@ -3083,7 +3092,44 @@ export class CodexClaudeAppServer {
       }
       if (files.length >= 100) break
     }
-    return { files }
+    return files
+  }
+
+  private fuzzySessionStart(params: Record<string, unknown>): unknown {
+    const sessionId = stringOr(params.sessionId, '')
+    const roots = Array.isArray(params.roots) ? params.roots.map(String) : [process.cwd()]
+    if (sessionId) this.fuzzySessions.set(sessionId, { roots })
+    return {}
+  }
+
+  private async fuzzySessionUpdate(
+    peer: RpcPeer,
+    params: Record<string, unknown>,
+  ): Promise<unknown> {
+    const sessionId = stringOr(params.sessionId, '')
+    const query = stringOr(params.query, '')
+    const session = this.fuzzySessions.get(sessionId)
+    const roots = session?.roots ?? [process.cwd()]
+    const files = await this.fuzzySearchCore(query, roots)
+    if (sessionId && this.fuzzySessions.get(sessionId) === session) {
+      this.notify(peer, {
+        method: 'fuzzyFileSearch/sessionUpdated',
+        params: { sessionId, query, files },
+      })
+    }
+    return {}
+  }
+
+  private fuzzySessionStop(peer: RpcPeer, params: Record<string, unknown>): unknown {
+    const sessionId = stringOr(params.sessionId, '')
+    this.fuzzySessions.delete(sessionId)
+    if (sessionId) {
+      this.notify(peer, {
+        method: 'fuzzyFileSearch/sessionCompleted',
+        params: { sessionId },
+      })
+    }
+    return {}
   }
 
   private toolUseToItem(

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3394,6 +3394,54 @@ test('mcpServerStatus/list enumerates tools and resources from the server', asyn
   }
 })
 
+test('fuzzyFileSearch session streams updated and completed notifications', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  await writeFile(join(home, 'findme-fixture.txt'), 'x')
+  const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+  })
+  const reader = new JsonLineReader(proc)
+  try {
+    proc.stdin.write(
+      json({
+        id: 1,
+        method: 'fuzzyFileSearch/sessionStart',
+        params: { sessionId: 's1', roots: [home] },
+      }),
+    )
+    await reader.nextResponse(1)
+
+    proc.stdin.write(
+      json({
+        id: 2,
+        method: 'fuzzyFileSearch/sessionUpdate',
+        params: { sessionId: 's1', query: 'findme' },
+      }),
+    )
+    const updated = await nextNotification(reader, 'fuzzyFileSearch/sessionUpdated')
+    assert.equal(updated.params.sessionId, 's1')
+    assert.equal(updated.params.query, 'findme')
+    const files = Array.isArray(updated.params.files) ? updated.params.files : []
+    assert.ok(
+      files.some((file: Record<string, unknown>) =>
+        String(file.path).endsWith('findme-fixture.txt'),
+      ),
+    )
+    await reader.nextResponse(2)
+
+    proc.stdin.write(
+      json({ id: 3, method: 'fuzzyFileSearch/sessionStop', params: { sessionId: 's1' } }),
+    )
+    const completed = await nextNotification(reader, 'fuzzyFileSearch/sessionCompleted')
+    assert.equal(completed.params.sessionId, 's1')
+    await reader.nextResponse(3)
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
 test('direct MCP HTTP tool calls work', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const httpServer = http.createServer((req, res) => {
@@ -3630,6 +3678,23 @@ class ChildProcessDuplex extends Duplex {
 
 function json(message: Record<string, unknown>): string {
   return `${JSON.stringify({ jsonrpc: '2.0', ...message })}\n`
+}
+
+async function nextNotification(
+  reader: JsonLineReader,
+  method: string,
+): Promise<{ params: Record<string, unknown> }> {
+  for (let i = 0; i < 50; i += 1) {
+    const message = await reader.next()
+    if (message.method === method) return { params: asTestRecord(message.params) }
+  }
+  throw new Error(`missing notification: ${method}`)
+}
+
+function asTestRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
 }
 
 function delay(ms: number): Promise<void> {

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3436,6 +3436,17 @@ test('fuzzyFileSearch session streams updated and completed notifications', asyn
     const completed = await nextNotification(reader, 'fuzzyFileSearch/sessionCompleted')
     assert.equal(completed.params.sessionId, 's1')
     await reader.nextResponse(3)
+
+    proc.stdin.write(
+      json({
+        id: 4,
+        method: 'fuzzyFileSearch/sessionUpdate',
+        params: { sessionId: 's1', query: 'findme' },
+      }),
+    )
+    const afterStop = await reader.next()
+    assert.equal(afterStop.id, 4)
+    assert.equal(afterStop.method, undefined)
   } finally {
     proc.kill()
     await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })


### PR DESCRIPTION
## Summary

- Implements the stateful `fuzzyFileSearch/sessionStart`, `sessionUpdate`, and `sessionStop` protocol surface.
- Reuses the existing one-shot fuzzy file search logic through a shared search helper.
- Emits `fuzzyFileSearch/sessionUpdated` and `fuzzyFileSearch/sessionCompleted` notifications for Codex App file-picker sessions.

## Scope

This PR intentionally includes only the fuzzy file search session slice and its focused stdio protocol test. It does not include the already-merged MCP status slice, PR #10, docs/provider work, skills/hooks, or thread turns `itemsView` work.

## Validation

Run under Node 24.14.0 via the bundled Codex runtime:

- `npm run build && node --test --test-name-pattern "fuzzyFileSearch session" dist/test/adapter.test.mjs`
- `npm test`
- `npm run typecheck`
- `npm run check` (exits 0; prints pre-existing warnings in unrelated files)
- `npm run docs:build`
