### PR TITLE
[codex] Support turn list item views

### DIFF
--- a/src/server.mts
+++ b/src/server.mts
@@ -106,6 +106,13 @@ import { maybeCreateThreadWorktree } from './worktree.mjs'
 
 const execFileAsync = promisify(execFile)
 
+type TurnItemsView = 'full' | 'summary' | 'notLoaded'
+
+function turnItemsView(value: unknown): TurnItemsView {
+  if (value === 'full' || value === 'summary' || value === 'notLoaded') return value
+  return 'summary'
+}
+
 export class CodexClaudeAppServer {
   private pendingServerRequests = new Map<
     string,
@@ -705,8 +712,9 @@ export class CodexClaudeAppServer {
 
   private threadTurnsList(params: Record<string, unknown>): unknown {
     const threadId = stringOr(params.threadId, '')
+    const itemsView = turnItemsView(params.itemsView)
     return {
-      data: this.store.listTurns(threadId).map((turn) => this.toTurn(turn)),
+      data: this.store.listTurns(threadId).map((turn) => this.toTurnView(turn, itemsView)),
       nextCursor: null,
       backwardsCursor: null,
     }
@@ -3247,6 +3255,26 @@ export class CodexClaudeAppServer {
       id: turn.id,
       items: turn.items,
       itemsView: 'full',
+      status: turn.status,
+      error: turn.error,
+      startedAt: turn.startedAt,
+      completedAt: turn.completedAt,
+      durationMs: turn.durationMs,
+    }
+  }
+
+  private toTurnView(turn: TurnRecord, itemsView: TurnItemsView): unknown {
+    if (itemsView === 'full') return this.toTurn(turn)
+    if (itemsView === 'notLoaded') return this.toLifecycleTurn(turn)
+    const firstUser = turn.items.find((item) => item.type === 'userMessage')
+    const lastAgent = turn.items.findLast((item) => item.type === 'agentMessage')
+    const items: ThreadItem[] = []
+    if (firstUser) items.push(firstUser)
+    if (lastAgent && lastAgent.id !== firstUser?.id) items.push(lastAgent)
+    return {
+      id: turn.id,
+      items,
+      itemsView: 'summary',
       status: turn.status,
       error: turn.error,
       startedAt: turn.startedAt,

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -250,6 +250,62 @@ test('turn lifecycle envelopes carry empty notLoaded items like the real app-ser
   }
 })
 
+test('thread/turns/list honors default summary and explicit itemsView', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+  })
+  const reader = new JsonLineReader(proc)
+  try {
+    proc.stdin.write(json({ id: 1, method: 'thread/start', params: { cwd: process.cwd() } }))
+    const start = await reader.nextResponse(1)
+    const threadId = start.result.thread.id
+
+    proc.stdin.write(
+      json({
+        id: 2,
+        method: 'turn/start',
+        params: { threadId, input: [{ type: 'text', text: 'hello', text_elements: [] }] },
+      }),
+    )
+    await reader.nextResponse(2)
+    for (let i = 0; i < 200; i += 1) {
+      const message = await reader.next()
+      if (message.method === 'turn/completed') break
+    }
+
+    proc.stdin.write(json({ id: 3, method: 'thread/turns/list', params: { threadId } }))
+    const summary = await reader.nextResponse(3)
+    const summaryTurn = summary.result.data[0]
+    assert.equal(summaryTurn.itemsView, 'summary')
+    assert.deepEqual(
+      summaryTurn.items.map((item: Record<string, unknown>) => item.type),
+      ['userMessage', 'agentMessage'],
+    )
+
+    proc.stdin.write(
+      json({ id: 4, method: 'thread/turns/list', params: { threadId, itemsView: 'notLoaded' } }),
+    )
+    const notLoaded = await reader.nextResponse(4)
+    assert.equal(notLoaded.result.data[0].itemsView, 'notLoaded')
+    assert.deepEqual(notLoaded.result.data[0].items, [])
+
+    proc.stdin.write(
+      json({ id: 5, method: 'thread/turns/list', params: { threadId, itemsView: 'full' } }),
+    )
+    const full = await reader.nextResponse(5)
+    const fullTurn = full.result.data[0]
+    assert.equal(fullTurn.itemsView, 'full')
+    assert.ok(fullTurn.items.length >= summaryTurn.items.length)
+    assert.ok(fullTurn.items.some((item: Record<string, unknown>) => item.type === 'userMessage'))
+    assert.ok(fullTurn.items.some((item: Record<string, unknown>) => item.type === 'agentMessage'))
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
 test('mcpServerStatus/list and startup notifications use conformant Codex v2 shapes', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {


### PR DESCRIPTION
## Summary

- Adds `itemsView` support to `thread/turns/list`.
- Defaults omitted or invalid `itemsView` values to `summary`.
- Supports explicit `itemsView: "notLoaded"` with empty items and `itemsView: "full"` with the existing full turn payload.

## Scope

This PR intentionally includes only the `thread/turns/list` `itemsView` protocol slice and its focused stdio test. It does not include provider/Rust/docs/dependency work, skills/hooks, MCP status, or fuzzy file search session changes beyond what is already on main.

## Validation

Run under Node 24.14.0 via the bundled Codex runtime:

- `npm run build && node --test --test-name-pattern "thread/turns/list honors" dist/test/adapter.test.mjs`
- `npm test`
- `npm run typecheck`
- `npm run check` (exits 0; prints pre-existing unrelated warnings)
- `npm run docs:build`
