### PR TITLE
[codex] Add provider loop descriptors

### DIFF
--- a/src/provider-loop-descriptor-schema.mts
+++ b/src/provider-loop-descriptor-schema.mts
@@ -1,0 +1,252 @@
+import {
+  APPROVAL_FIDELITY_LEVELS,
+  CREDENTIAL_SOURCES,
+  type CredentialSource,
+  DESCRIPTOR_STATUSES,
+  type DescriptorValidationIssue,
+  EVENT_FIDELITY_LEVELS,
+  GATEWAY_POLICIES,
+  PROVIDER_FAMILIES,
+  type ProviderLoopDescriptorDraft,
+  UNSUPPORTED_CREDENTIAL_SOURCES,
+  type UnsupportedCredentialSource,
+} from './provider-loop-descriptor-types.mjs'
+
+const STRING_FIELDS = [
+  'id',
+  'displayName',
+  'status',
+  'providerFamily',
+  'gatewayPolicy',
+  'loopId',
+  'eventFidelity',
+  'approvalFidelity',
+] as const
+
+const BOOLEAN_FIELDS = ['supportsSteer', 'supportsInterrupt', 'supportsResume'] as const
+
+type StringField = (typeof STRING_FIELDS)[number]
+
+interface KnownStringCheck {
+  readonly field: StringField
+  readonly values: ReadonlySet<string>
+}
+
+const KNOWN_STRING_CHECKS: readonly KnownStringCheck[] = [
+  { field: 'status', values: new Set(DESCRIPTOR_STATUSES) },
+  { field: 'providerFamily', values: new Set(PROVIDER_FAMILIES) },
+  { field: 'gatewayPolicy', values: new Set(GATEWAY_POLICIES) },
+  { field: 'eventFidelity', values: new Set(EVENT_FIDELITY_LEVELS) },
+  { field: 'approvalFidelity', values: new Set(APPROVAL_FIDELITY_LEVELS) },
+]
+
+const CREDENTIAL_SOURCE_SET: ReadonlySet<string> = new Set(CREDENTIAL_SOURCES)
+const UNSUPPORTED_CREDENTIAL_SOURCE_SET: ReadonlySet<string> = new Set(
+  UNSUPPORTED_CREDENTIAL_SOURCES,
+)
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b((?:[A-Z0-9_]*_)?(?:API[_-]?KEY|TOKEN|PASSWORD|SECRET))\s*[:=]\s*(?:Bearer\s+)?[A-Za-z0-9._~+/=-]{8,}/gi
+
+const SECRET_VALUE_PATTERNS = [
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\bsk-(?:ant|proj)?-[A-Za-z0-9_-]{8,}/gi,
+  /\bgh[opsu]_[A-Za-z0-9_]{8,}/gi,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+] as const
+
+export function validateProviderLoopDescriptors(
+  descriptors: readonly ProviderLoopDescriptorDraft[],
+): readonly DescriptorValidationIssue[] {
+  return descriptors.flatMap((descriptor) => validateProviderLoopDescriptor(descriptor))
+}
+
+export function credentialSourcesForProjection(
+  descriptor: Pick<ProviderLoopDescriptorDraft, 'allowedCredentialSources'>,
+): readonly CredentialSource[] {
+  const projected: CredentialSource[] = []
+  for (const source of descriptor.allowedCredentialSources ?? []) {
+    if (isCredentialSource(source) && !projected.includes(source)) projected.push(source)
+  }
+  return projected
+}
+
+export function hasSecretLikeText(value: string): boolean {
+  if (secretPatternMatches(SECRET_ASSIGNMENT_PATTERN, value)) return true
+  return SECRET_VALUE_PATTERNS.some((pattern) => secretPatternMatches(pattern, value))
+}
+
+export function redactSecretLikeText(value: string): string {
+  let redacted = value.replace(
+    SECRET_ASSIGNMENT_PATTERN,
+    (_match, keyName: string) => `${keyName}=[redacted]`,
+  )
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    pattern.lastIndex = 0
+    redacted = redacted.replace(pattern, '[redacted]')
+  }
+  return redacted
+}
+
+function validateProviderLoopDescriptor(
+  descriptor: ProviderLoopDescriptorDraft,
+): readonly DescriptorValidationIssue[] {
+  const descriptorId = descriptorIdForIssue(descriptor)
+  const issues: DescriptorValidationIssue[] = []
+
+  for (const field of STRING_FIELDS) {
+    const value = descriptor[field]
+    if (typeof value !== 'string' || value.trim() === '') {
+      issues.push({
+        descriptorId,
+        field,
+        code: 'missing-field',
+        message: 'required string field is missing',
+      })
+      continue
+    }
+    if (hasSecretLikeText(value)) {
+      issues.push({
+        descriptorId,
+        field,
+        code: 'secret-like-value',
+        message: 'field contains a secret-like value',
+      })
+    }
+  }
+
+  for (const field of BOOLEAN_FIELDS) {
+    if (typeof descriptor[field] !== 'boolean') {
+      issues.push({
+        descriptorId,
+        field,
+        code: 'invalid-value',
+        message: 'required boolean field is invalid',
+      })
+    }
+  }
+
+  for (const check of KNOWN_STRING_CHECKS) {
+    const value = descriptor[check.field]
+    if (typeof value === 'string' && value.trim() && !check.values.has(value)) {
+      issues.push({
+        descriptorId,
+        field: check.field,
+        code: 'invalid-value',
+        message: `${value} is not a supported ${check.field} value`,
+      })
+    }
+  }
+
+  validateCredentialSources(descriptorId, descriptor.allowedCredentialSources, issues)
+  validateUnsupportedCredentialSources(
+    descriptorId,
+    descriptor.unsupportedCredentialSources,
+    issues,
+  )
+  validateComplianceNotes(descriptorId, descriptor.complianceNotes, issues)
+  return issues
+}
+
+function validateCredentialSources(
+  descriptorId: string,
+  sources: readonly string[] | undefined,
+  issues: DescriptorValidationIssue[],
+): void {
+  if (!sources) {
+    issues.push({
+      descriptorId,
+      field: 'allowedCredentialSources',
+      code: 'missing-field',
+      message: 'allowed credential sources are missing',
+    })
+    return
+  }
+  for (const source of sources) {
+    if (isUnsupportedCredentialSource(source)) {
+      issues.push({
+        descriptorId,
+        field: 'allowedCredentialSources',
+        code: 'unsupported-credential-source',
+        message: `${source} cannot be projected as supported`,
+      })
+    } else if (!isCredentialSource(source)) {
+      issues.push({
+        descriptorId,
+        field: 'allowedCredentialSources',
+        code: 'invalid-value',
+        message: `${source} is not a supported credential source label`,
+      })
+    }
+  }
+}
+
+function validateUnsupportedCredentialSources(
+  descriptorId: string,
+  sources: readonly string[] | undefined,
+  issues: DescriptorValidationIssue[],
+): void {
+  if (!sources) {
+    issues.push({
+      descriptorId,
+      field: 'unsupportedCredentialSources',
+      code: 'missing-field',
+      message: 'unsupported credential sources are missing',
+    })
+    return
+  }
+  for (const source of sources) {
+    if (!isUnsupportedCredentialSource(source)) {
+      issues.push({
+        descriptorId,
+        field: 'unsupportedCredentialSources',
+        code: 'invalid-value',
+        message: `${source} is not an unsupported credential source label`,
+      })
+    }
+  }
+}
+
+function validateComplianceNotes(
+  descriptorId: string,
+  notes: readonly string[] | undefined,
+  issues: DescriptorValidationIssue[],
+): void {
+  if (!notes) {
+    issues.push({
+      descriptorId,
+      field: 'complianceNotes',
+      code: 'missing-field',
+      message: 'compliance notes are missing',
+    })
+    return
+  }
+  for (const note of notes) {
+    if (hasSecretLikeText(note)) {
+      issues.push({
+        descriptorId,
+        field: 'complianceNotes',
+        code: 'secret-like-value',
+        message: 'compliance note contains a secret-like value',
+      })
+    }
+  }
+}
+
+function descriptorIdForIssue(descriptor: ProviderLoopDescriptorDraft): string {
+  return typeof descriptor.id === 'string' && descriptor.id.trim() ? descriptor.id : '<unknown>'
+}
+
+function secretPatternMatches(pattern: RegExp, value: string): boolean {
+  pattern.lastIndex = 0
+  return pattern.test(value)
+}
+
+function isCredentialSource(value: string): value is CredentialSource {
+  return CREDENTIAL_SOURCE_SET.has(value)
+}
+
+function isUnsupportedCredentialSource(value: string): value is UnsupportedCredentialSource {
+  return UNSUPPORTED_CREDENTIAL_SOURCE_SET.has(value)
+}

--- a/src/provider-loop-descriptor-types.mts
+++ b/src/provider-loop-descriptor-types.mts
@@ -1,0 +1,82 @@
+export const CREDENTIAL_SOURCES = [
+  'user-api-key',
+  'cloud-provider',
+  'organization-gateway',
+  'local-cli-auth',
+] as const
+
+export const UNSUPPORTED_CREDENTIAL_SOURCES = [
+  'personal-subscription',
+  'personal-session',
+  'browser-cookie',
+  'oauth-session',
+  'cli-session-export',
+  'credential-sharing',
+  'private-proxy',
+  'provider-bypass',
+] as const
+
+export const DESCRIPTOR_STATUSES = ['stable', 'experimental'] as const
+export const PROVIDER_FAMILIES = ['anthropic', 'openai'] as const
+export const GATEWAY_POLICIES = ['none', 'official-or-organization-managed'] as const
+export const EVENT_FIDELITY_LEVELS = ['rich', 'jsonl', 'message-level', 'transcript'] as const
+export const APPROVAL_FIDELITY_LEVELS = [
+  'native-file-diff',
+  'native-codex',
+  'limited',
+  'none',
+] as const
+
+type DescriptorStatus = (typeof DESCRIPTOR_STATUSES)[number]
+type ProviderFamily = (typeof PROVIDER_FAMILIES)[number]
+type GatewayPolicy = (typeof GATEWAY_POLICIES)[number]
+type EventFidelity = (typeof EVENT_FIDELITY_LEVELS)[number]
+type ApprovalFidelity = (typeof APPROVAL_FIDELITY_LEVELS)[number]
+
+export type CredentialSource = (typeof CREDENTIAL_SOURCES)[number]
+export type UnsupportedCredentialSource = (typeof UNSUPPORTED_CREDENTIAL_SOURCES)[number]
+
+export interface ProviderLoopDescriptor {
+  readonly id: string
+  readonly displayName: string
+  readonly status: DescriptorStatus
+  readonly providerFamily: ProviderFamily
+  readonly allowedCredentialSources: readonly CredentialSource[]
+  readonly gatewayPolicy: GatewayPolicy
+  readonly loopId: string
+  readonly eventFidelity: EventFidelity
+  readonly approvalFidelity: ApprovalFidelity
+  readonly supportsSteer: boolean
+  readonly supportsInterrupt: boolean
+  readonly supportsResume: boolean
+  readonly complianceNotes: readonly string[]
+  readonly unsupportedCredentialSources: readonly UnsupportedCredentialSource[]
+}
+
+export interface ProviderLoopDescriptorDraft {
+  readonly id?: unknown
+  readonly displayName?: unknown
+  readonly status?: unknown
+  readonly providerFamily?: unknown
+  readonly allowedCredentialSources?: readonly string[]
+  readonly gatewayPolicy?: unknown
+  readonly loopId?: unknown
+  readonly eventFidelity?: unknown
+  readonly approvalFidelity?: unknown
+  readonly supportsSteer?: unknown
+  readonly supportsInterrupt?: unknown
+  readonly supportsResume?: unknown
+  readonly complianceNotes?: readonly string[]
+  readonly unsupportedCredentialSources?: readonly string[]
+}
+
+export interface DescriptorValidationIssue {
+  readonly descriptorId: string
+  readonly field: string
+  readonly code:
+    | 'missing-field'
+    | 'invalid-value'
+    | 'unsupported-credential-source'
+    | 'secret-like-value'
+  readonly message: string
+}

--- a/src/provider-loop-descriptors.mts
+++ b/src/provider-loop-descriptors.mts
@@ -1,0 +1,72 @@
+export {
+  credentialSourcesForProjection,
+  hasSecretLikeText,
+  redactSecretLikeText,
+  validateProviderLoopDescriptors,
+} from './provider-loop-descriptor-schema.mjs'
+export type {
+  CredentialSource,
+  DescriptorValidationIssue,
+  ProviderLoopDescriptor,
+  ProviderLoopDescriptorDraft,
+  UnsupportedCredentialSource,
+} from './provider-loop-descriptor-types.mjs'
+export {
+  CREDENTIAL_SOURCES,
+  DESCRIPTOR_STATUSES,
+  EVENT_FIDELITY_LEVELS,
+  GATEWAY_POLICIES,
+  PROVIDER_FAMILIES,
+  UNSUPPORTED_CREDENTIAL_SOURCES,
+} from './provider-loop-descriptor-types.mjs'
+
+import {
+  type ProviderLoopDescriptor,
+  UNSUPPORTED_CREDENTIAL_SOURCES,
+} from './provider-loop-descriptor-types.mjs'
+
+export const PROVIDER_LOOP_DESCRIPTORS = [
+  {
+    id: 'claude-code',
+    displayName: 'Claude Code',
+    status: 'stable',
+    providerFamily: 'anthropic',
+    allowedCredentialSources: [
+      'user-api-key',
+      'cloud-provider',
+      'organization-gateway',
+      'local-cli-auth',
+    ],
+    gatewayPolicy: 'official-or-organization-managed',
+    loopId: 'native-claude-code-sdk',
+    eventFidelity: 'rich',
+    approvalFidelity: 'native-file-diff',
+    supportsSteer: true,
+    supportsInterrupt: true,
+    supportsResume: true,
+    complianceNotes: [
+      'Credentials stay on the user host, cloud provider chain, or organization gateway.',
+      'Local CLI auth is local-only and not a productized credential distribution model.',
+    ],
+    unsupportedCredentialSources: UNSUPPORTED_CREDENTIAL_SOURCES,
+  },
+  {
+    id: 'codex',
+    displayName: 'Codex proxy',
+    status: 'stable',
+    providerFamily: 'openai',
+    allowedCredentialSources: ['local-cli-auth'],
+    gatewayPolicy: 'none',
+    loopId: 'codex-jsonl-proxy',
+    eventFidelity: 'jsonl',
+    approvalFidelity: 'native-codex',
+    supportsSteer: false,
+    supportsInterrupt: true,
+    supportsResume: true,
+    complianceNotes: [
+      'Auth remains owned by the local Codex CLI on the user host.',
+      'The adapter does not collect or redistribute Codex subscription/session credentials.',
+    ],
+    unsupportedCredentialSources: UNSUPPORTED_CREDENTIAL_SOURCES,
+  },
+] as const satisfies readonly ProviderLoopDescriptor[]

--- a/test/provider-loop-descriptors.test.mts
+++ b/test/provider-loop-descriptors.test.mts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  credentialSourcesForProjection,
+  hasSecretLikeText,
+  PROVIDER_LOOP_DESCRIPTORS,
+  redactSecretLikeText,
+  validateProviderLoopDescriptors,
+} from '../src/provider-loop-descriptors.mjs'
+
+test('provider loop descriptors validate existing safe surfaces', () => {
+  const issues = validateProviderLoopDescriptors(PROVIDER_LOOP_DESCRIPTORS)
+
+  assert.deepEqual(issues, [])
+  assert.deepEqual(
+    PROVIDER_LOOP_DESCRIPTORS.map((descriptor) => descriptor.id),
+    ['claude-code', 'codex'],
+  )
+})
+
+test('credential projection excludes unsupported personal-session labels', () => {
+  const projected = credentialSourcesForProjection({
+    allowedCredentialSources: [
+      'user-api-key',
+      'personal-session',
+      'browser-cookie',
+      'organization-gateway',
+    ],
+  })
+
+  assert.deepEqual(projected, ['user-api-key', 'organization-gateway'])
+})
+
+test('descriptor validation rejects unsupported credential sources as supported', () => {
+  const issues = validateProviderLoopDescriptors([
+    {
+      id: 'invalid-provider',
+      displayName: 'Invalid Provider',
+      status: 'experimental',
+      providerFamily: 'anthropic',
+      allowedCredentialSources: ['personal-subscription'],
+      gatewayPolicy: 'none',
+      loopId: 'invalid-loop',
+      eventFidelity: 'transcript',
+      approvalFidelity: 'none',
+      supportsSteer: false,
+      supportsInterrupt: false,
+      supportsResume: false,
+      complianceNotes: ['fake descriptor for validation only'],
+      unsupportedCredentialSources: ['personal-subscription'],
+    },
+  ])
+
+  assert.deepEqual(
+    issues.map((issue) => issue.code),
+    ['unsupported-credential-source'],
+  )
+})
+
+test('descriptor validation detects and redacts secret-like values', () => {
+  const fakeSecret = 'ANTHROPIC_API_KEY=sk-ant-fake000000000000000000000000000000'
+  const issues = validateProviderLoopDescriptors([
+    {
+      id: 'secret-provider',
+      displayName: 'Secret Provider',
+      status: 'experimental',
+      providerFamily: 'anthropic',
+      allowedCredentialSources: ['user-api-key'],
+      gatewayPolicy: 'none',
+      loopId: 'secret-loop',
+      eventFidelity: 'transcript',
+      approvalFidelity: 'none',
+      supportsSteer: false,
+      supportsInterrupt: false,
+      supportsResume: false,
+      complianceNotes: [`fake note ${fakeSecret}`],
+      unsupportedCredentialSources: ['personal-session'],
+    },
+  ])
+
+  assert.equal(hasSecretLikeText(fakeSecret), true)
+  assert.equal(redactSecretLikeText(fakeSecret), 'ANTHROPIC_API_KEY=[redacted]')
+  assert.deepEqual(
+    issues.map((issue) => issue.code),
+    ['secret-like-value'],
+  )
+})


### PR DESCRIPTION
## Summary

- add typed provider/agent-loop descriptor constants for the existing Claude Code and Codex proxy surfaces
- add validation helpers for descriptor shape, supported credential labels, unsupported personal-session labels, and secret-like text detection/redaction
- add focused unit coverage for static descriptor validity, credential projection boundaries, and fake-secret redaction

## Scope

This is RFC Phase 1 only: static config/schema/test coverage. It does not change runtime execution, auth behavior, config/read projection, docs wording, dependencies, Rust work, `src/server.mts`, or `test/adapter.test.mts`.

## Validation

All commands were run through Node 24 via `npx -y -p node@24 -c ...` after rebasing onto `origin/main` containing PR #16 (`3d19154`).

- `npm run build && node --test dist/test/provider-loop-descriptors.test.mjs`
- `npm test`
- `npm run typecheck`
- `npm run check` (exits 0; reports pre-existing warnings outside the new descriptor files)
- `npm run docs:build`
- `git diff --check`

## Follow-up

RFC Phase 2 can wire these descriptors into read-only config projection once the team chooses the public selector shape and confirms which Codex App config fields should remain inert.