### PR TITLE
Surface Claude skills and hooks

### DIFF
--- a/src/claude-capabilities.mts
+++ b/src/claude-capabilities.mts
@@ -92,6 +92,7 @@ function readSkillDir(
   return { skills, errors }
 }
 
+// Claude events without a Codex hook surface, such as Notification, are intentionally dropped.
 const HOOK_EVENT_MAP: Record<string, string> = {
   PreToolUse: 'preToolUse',
   PostToolUse: 'postToolUse',

--- a/src/claude-capabilities.mts
+++ b/src/claude-capabilities.mts
@@ -1,0 +1,199 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+interface SkillMetadata {
+  readonly name: string
+  readonly description: string
+  readonly shortDescription?: string
+  readonly path: string
+  readonly scope: 'user' | 'repo' | 'system' | 'admin'
+  readonly enabled: boolean
+}
+
+interface SkillsListEntry {
+  readonly cwd: string
+  readonly skills: readonly SkillMetadata[]
+  readonly errors: ReadonlyArray<{ readonly path: string; readonly message: string }>
+}
+
+interface HookMetadata {
+  readonly key: string
+  readonly eventName: string
+  readonly handlerType: 'command' | 'prompt' | 'agent'
+  readonly matcher: string | null
+  readonly command: string | null
+  readonly timeoutSec: number
+  readonly statusMessage: string | null
+  readonly sourcePath: string
+  readonly source: 'system' | 'user' | 'project' | 'plugin' | 'unknown'
+  readonly pluginId: string | null
+  readonly displayOrder: number
+  readonly enabled: boolean
+  readonly isManaged: boolean
+  readonly currentHash: string
+  readonly trustStatus: 'managed' | 'untrusted' | 'trusted' | 'modified'
+}
+
+interface HooksListEntry {
+  readonly cwd: string
+  readonly hooks: readonly HookMetadata[]
+  readonly warnings: readonly string[]
+  readonly errors: ReadonlyArray<{ readonly path: string; readonly message: string }>
+}
+
+export function listClaudeSkills(params: Record<string, unknown>): SkillsListEntry[] {
+  const roots = cwdsFromParams(params)
+  const userSkills = readSkillDir(join(homedir(), '.claude', 'skills'), 'user')
+  return roots.map((cwd) => {
+    const repo = readSkillDir(join(cwd, '.claude', 'skills'), 'repo')
+    return {
+      cwd,
+      skills: [...userSkills.skills, ...repo.skills],
+      errors: [...userSkills.errors, ...repo.errors],
+    }
+  })
+}
+
+function readSkillDir(
+  dir: string,
+  scope: 'user' | 'repo',
+): { skills: SkillMetadata[]; errors: Array<{ path: string; message: string }> } {
+  const skills: SkillMetadata[] = []
+  const errors: Array<{ path: string; message: string }> = []
+  if (!existsSync(dir)) return { skills, errors }
+  let entries: string[] = []
+  try {
+    entries = readdirSync(dir)
+  } catch (error) {
+    errors.push({ path: dir, message: messageOf(error) })
+    return { skills, errors }
+  }
+  for (const entry of entries) {
+    const skillPath = join(dir, entry)
+    const manifest = join(skillPath, 'SKILL.md')
+    try {
+      if (!statSync(skillPath).isDirectory() || !existsSync(manifest)) continue
+      const frontmatter = parseFrontmatter(readFileSync(manifest, 'utf8'))
+      const name = frontmatter.name || entry
+      skills.push({
+        name,
+        description: frontmatter.description || '',
+        ...(frontmatter.description ? { shortDescription: frontmatter.description } : {}),
+        path: skillPath,
+        scope,
+        enabled: true,
+      })
+    } catch (error) {
+      errors.push({ path: manifest, message: messageOf(error) })
+    }
+  }
+  return { skills, errors }
+}
+
+const HOOK_EVENT_MAP: Record<string, string> = {
+  PreToolUse: 'preToolUse',
+  PostToolUse: 'postToolUse',
+  PermissionRequest: 'permissionRequest',
+  PreCompact: 'preCompact',
+  PostCompact: 'postCompact',
+  SessionStart: 'sessionStart',
+  UserPromptSubmit: 'userPromptSubmit',
+  Stop: 'stop',
+}
+
+export function listClaudeHooks(params: Record<string, unknown>): HooksListEntry[] {
+  const roots = cwdsFromParams(params)
+  const userSources = [
+    { path: join(homedir(), '.claude', 'settings.json'), source: 'user' as const },
+  ]
+  return roots.map((cwd) => {
+    const sources = [
+      ...userSources,
+      { path: join(cwd, '.claude', 'settings.json'), source: 'project' as const },
+      { path: join(cwd, '.claude', 'settings.local.json'), source: 'project' as const },
+    ]
+    const hooks: HookMetadata[] = []
+    const errors: Array<{ path: string; message: string }> = []
+    let order = 0
+    for (const { path, source } of sources) {
+      if (!existsSync(path)) continue
+      let parsed: Record<string, unknown>
+      try {
+        parsed = JSON.parse(readFileSync(path, 'utf8'))
+      } catch (error) {
+        errors.push({ path, message: messageOf(error) })
+        continue
+      }
+      const hookConfig = asRecord(parsed.hooks)
+      for (const [claudeEvent, eventName] of Object.entries(HOOK_EVENT_MAP)) {
+        const matchers = hookConfig[claudeEvent]
+        if (!Array.isArray(matchers)) continue
+        for (const rawMatcher of matchers) {
+          const matcherEntry = asRecord(rawMatcher)
+          const matcher = typeof matcherEntry.matcher === 'string' ? matcherEntry.matcher : null
+          const handlers = Array.isArray(matcherEntry.hooks) ? matcherEntry.hooks : []
+          for (const rawHandler of handlers) {
+            const handler = asRecord(rawHandler)
+            const command = typeof handler.command === 'string' ? handler.command : null
+            const handlerType =
+              handler.type === 'prompt' ? 'prompt' : handler.type === 'agent' ? 'agent' : 'command'
+            hooks.push({
+              key: `${source}:${eventName}:${order}`,
+              eventName,
+              handlerType,
+              matcher,
+              command,
+              timeoutSec: typeof handler.timeout === 'number' ? handler.timeout : 60,
+              statusMessage: null,
+              sourcePath: path,
+              source,
+              pluginId: null,
+              displayOrder: order,
+              enabled: true,
+              isManaged: false,
+              currentHash: createHash('sha256')
+                .update(`${eventName}:${matcher ?? ''}:${command ?? ''}`)
+                .digest('hex'),
+              trustStatus: 'trusted',
+            })
+            order += 1
+          }
+        }
+      }
+    }
+    return { cwd, hooks, warnings: [], errors }
+  })
+}
+
+function cwdsFromParams(params: Record<string, unknown>): string[] {
+  const cwds = Array.isArray(params.cwds) ? params.cwds.map(String).filter(Boolean) : []
+  return cwds.length > 0 ? cwds : [process.cwd()]
+}
+
+function parseFrontmatter(text: string): { name?: string; description?: string } {
+  if (!text.startsWith('---')) return {}
+  const end = text.indexOf('\n---', 3)
+  if (end < 0) return {}
+  const body = text.slice(3, end)
+  const out: { name?: string; description?: string } = {}
+  for (const line of body.split('\n')) {
+    const match = /^\s*(name|description)\s*:\s*(.+?)\s*$/.exec(line)
+    if (!match) continue
+    const value = (match[2] ?? '').replace(/^["']|["']$/g, '')
+    if (match[1] === 'name') out.name = value
+    else out.description = value
+  }
+  return out
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/server.mts
+++ b/src/server.mts
@@ -2,6 +2,7 @@ import { type ChildProcess, execFile, spawn } from 'node:child_process'
 import { type FSWatcher, readFileSync, watch, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
+import { listClaudeHooks, listClaudeSkills } from './claude-capabilities.mjs'
 import { callMcpTool, listMcpServerStatuses, readMcpConfig, readMcpResource } from './mcp.mjs'
 import {
   addedFileDiff,
@@ -370,9 +371,9 @@ export class CodexClaudeAppServer {
           echoed: typeof asRecord(params).value === 'string' ? asRecord(params).value : null,
         }
       case 'skills/list':
-        return { data: [] }
+        return { data: listClaudeSkills(asRecord(params)) }
       case 'hooks/list':
-        return { data: [] }
+        return { data: listClaudeHooks(asRecord(params)) }
       case 'marketplace/add':
         return this.marketplaceAdd(asRecord(params))
       case 'marketplace/remove':

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3512,6 +3512,19 @@ test('fuzzyFileSearch session streams updated and completed notifications', asyn
 test('skills/list and hooks/list surface Claude Code skills and settings hooks', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const workspace = join(home, 'ws')
+  await mkdir(join(home, '.claude', 'skills', 'user-skill'), { recursive: true })
+  await writeFile(
+    join(home, '.claude', 'skills', 'user-skill', 'SKILL.md'),
+    '---\nname: user-skill\ndescription: A user skill for tests\n---\nbody\n',
+  )
+  await writeFile(
+    join(home, '.claude', 'settings.json'),
+    JSON.stringify({
+      hooks: {
+        PostToolUse: [{ matcher: 'Edit', hooks: [{ type: 'command', command: 'echo user' }] }],
+      },
+    }),
+  )
   await mkdir(join(workspace, '.claude', 'skills', 'demo-skill'), { recursive: true })
   await writeFile(
     join(workspace, '.claude', 'skills', 'demo-skill', 'SKILL.md'),
@@ -3528,7 +3541,13 @@ test('skills/list and hooks/list surface Claude Code skills and settings hooks',
   )
   const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+    env: {
+      ...process.env,
+      CODEX_HOME: home,
+      HOME: home,
+      CLAUDE_CODEX_MOCK: '1',
+      NODE_NO_WARNINGS: '1',
+    },
   })
   const reader = new JsonLineReader(proc)
   try {
@@ -3542,6 +3561,13 @@ test('skills/list and hooks/list surface Claude Code skills and settings hooks',
     assert.equal(demo.description, 'A demo skill for tests')
     assert.equal(demo.scope, 'repo')
     assert.equal(demo.enabled, true)
+    const userSkill = skillList.find(
+      (skill: Record<string, unknown>) => skill.name === 'user-skill',
+    )
+    assert.ok(userSkill, 'expected the user skill enumerated from HOME/.claude/skills')
+    assert.equal(userSkill.description, 'A user skill for tests')
+    assert.equal(userSkill.scope, 'user')
+    assert.equal(userSkill.enabled, true)
 
     proc.stdin.write(json({ id: 2, method: 'hooks/list', params: { cwds: [workspace] } }))
     const hooks = await reader.nextResponse(2)
@@ -3558,6 +3584,13 @@ test('skills/list and hooks/list surface Claude Code skills and settings hooks',
     assert.equal(pre.matcher, 'Bash')
     assert.equal(pre.handlerType, 'command')
     assert.ok(typeof pre.currentHash === 'string' && pre.currentHash.length > 0)
+    const userHook = hookList.find(
+      (hook: Record<string, unknown>) => hook.source === 'user' && hook.command === 'echo user',
+    )
+    assert.ok(userHook, 'expected the user settings hook mapped from HOME/.claude/settings.json')
+    assert.equal(userHook.eventName, 'postToolUse')
+    assert.equal(userHook.matcher, 'Edit')
+    assert.equal(userHook.handlerType, 'command')
     assert.ok(!hookList.some((hook: Record<string, unknown>) => hook.eventName === 'notification'))
   } finally {
     proc.kill()

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3509,6 +3509,62 @@ test('fuzzyFileSearch session streams updated and completed notifications', asyn
   }
 })
 
+test('skills/list and hooks/list surface Claude Code skills and settings hooks', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const workspace = join(home, 'ws')
+  await mkdir(join(workspace, '.claude', 'skills', 'demo-skill'), { recursive: true })
+  await writeFile(
+    join(workspace, '.claude', 'skills', 'demo-skill', 'SKILL.md'),
+    '---\nname: demo-skill\ndescription: A demo skill for tests\n---\nbody\n',
+  )
+  await writeFile(
+    join(workspace, '.claude', 'settings.json'),
+    JSON.stringify({
+      hooks: {
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'echo hi' }] }],
+        Notification: [{ hooks: [{ type: 'command', command: 'ignored' }] }],
+      },
+    }),
+  )
+  const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+  })
+  const reader = new JsonLineReader(proc)
+  try {
+    proc.stdin.write(json({ id: 1, method: 'skills/list', params: { cwds: [workspace] } }))
+    const skills = await reader.nextResponse(1)
+    const entry = skills.result.data.find((item: Record<string, unknown>) => item.cwd === workspace)
+    assert.ok(entry, 'expected a skills entry for the workspace cwd')
+    const skillList = Array.isArray(entry.skills) ? entry.skills : []
+    const demo = skillList.find((skill: Record<string, unknown>) => skill.name === 'demo-skill')
+    assert.ok(demo, 'expected the demo skill enumerated from .claude/skills')
+    assert.equal(demo.description, 'A demo skill for tests')
+    assert.equal(demo.scope, 'repo')
+    assert.equal(demo.enabled, true)
+
+    proc.stdin.write(json({ id: 2, method: 'hooks/list', params: { cwds: [workspace] } }))
+    const hooks = await reader.nextResponse(2)
+    const hooksEntry = hooks.result.data.find(
+      (item: Record<string, unknown>) => item.cwd === workspace,
+    )
+    assert.ok(hooksEntry, 'expected a hooks entry for the workspace cwd')
+    const hookList = Array.isArray(hooksEntry.hooks) ? hooksEntry.hooks : []
+    const pre = hookList.find(
+      (hook: Record<string, unknown>) => hook.source === 'project' && hook.command === 'echo hi',
+    )
+    assert.ok(pre, 'expected the project PreToolUse hook mapped to preToolUse')
+    assert.equal(pre.eventName, 'preToolUse')
+    assert.equal(pre.matcher, 'Bash')
+    assert.equal(pre.handlerType, 'command')
+    assert.ok(typeof pre.currentHash === 'string' && pre.currentHash.length > 0)
+    assert.ok(!hookList.some((hook: Record<string, unknown>) => hook.eventName === 'notification'))
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
 test('direct MCP HTTP tool calls work', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const httpServer = http.createServer((req, res) => {


### PR DESCRIPTION
## Summary
- add a Claude capabilities reader for skills/list and hooks/list
- enumerate repo/user .claude skills from SKILL.md frontmatter
- enumerate Claude settings hooks and map supported events to Codex-style hook metadata
- add focused stdio protocol coverage for skills/list and hooks/list

## Validation
- PATH=/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/Holegots/bin:/Users/Holegots/bin:/Users/Holegots/.codex/tmp/arg0/codex-arg0K90kZr:/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/Holegots/.local/bin:/Users/Holegots/.nvm/versions/node/v22.20.0/bin:/Users/Holegots/.antigravity/antigravity/bin:/Users/Holegots/.local/share/solana/install/active_release/bin:/opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/curl/bin:/Users/Holegots/.pyenv/shims:/usr/local/opt/icu4c/sbin:/usr/local/opt/icu4c/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/Holegots/.local/share/solana/install/active_release/bin:/Users/Holegots/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/Holegots/.orbstack/bin:/Applications/Obsidian.app/Contents/MacOS:/Users/Holegots/.spicetify:/Users/Holegots/go/bin:/Applications/Codex.app/Contents/Resources npm run build && node --test --test-name-pattern "skills/list and hooks/list" dist/test/adapter.test.mjs
- PATH=/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/Holegots/bin:/Users/Holegots/bin:/Users/Holegots/.codex/tmp/arg0/codex-arg0K90kZr:/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/Holegots/.local/bin:/Users/Holegots/.nvm/versions/node/v22.20.0/bin:/Users/Holegots/.antigravity/antigravity/bin:/Users/Holegots/.local/share/solana/install/active_release/bin:/opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/curl/bin:/Users/Holegots/.pyenv/shims:/usr/local/opt/icu4c/sbin:/usr/local/opt/icu4c/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/Holegots/.local/share/solana/install/active_release/bin:/Users/Holegots/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/Holegots/.orbstack/bin:/Applications/Obsidian.app/Contents/MacOS:/Users/Holegots/.spicetify:/Users/Holegots/go/bin:/Applications/Codex.app/Contents/Resources npm test
- PATH=/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/Holegots/bin:/Users/Holegots/bin:/Users/Holegots/.codex/tmp/arg0/codex-arg0K90kZr:/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/Holegots/.local/bin:/Users/Holegots/.nvm/versions/node/v22.20.0/bin:/Users/Holegots/.antigravity/antigravity/bin:/Users/Holegots/.local/share/solana/install/active_release/bin:/opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/curl/bin:/Users/Holegots/.pyenv/shims:/usr/local/opt/icu4c/sbin:/usr/local/opt/icu4c/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/Holegots/.local/share/solana/install/active_release/bin:/Users/Holegots/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/Holegots/.orbstack/bin:/Applications/Obsidian.app/Contents/MacOS:/Users/Holegots/.spicetify:/Users/Holegots/go/bin:/Applications/Codex.app/Contents/Resources npm run typecheck
- PATH=/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/Holegots/bin:/Users/Holegots/bin:/Users/Holegots/.codex/tmp/arg0/codex-arg0K90kZr:/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/Holegots/.local/bin:/Users/Holegots/.nvm/versions/node/v22.20.0/bin:/Users/Holegots/.antigravity/antigravity/bin:/Users/Holegots/.local/share/solana/install/active_release/bin:/opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/curl/bin:/Users/Holegots/.pyenv/shims:/usr/local/opt/icu4c/sbin:/usr/local/opt/icu4c/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/Holegots/.local/share/solana/install/active_release/bin:/Users/Holegots/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/Holegots/.orbstack/bin:/Applications/Obsidian.app/Contents/MacOS:/Users/Holegots/.spicetify:/Users/Holegots/go/bin:/Applications/Codex.app/Contents/Resources npm run check
- PATH=/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/Holegots/bin:/Users/Holegots/bin:/Users/Holegots/.codex/tmp/arg0/codex-arg0K90kZr:/Users/Holegots/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/Holegots/.local/bin:/Users/Holegots/.nvm/versions/node/v22.20.0/bin:/Users/Holegots/.antigravity/antigravity/bin:/Users/Holegots/.local/share/solana/install/active_release/bin:/opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/curl/bin:/Users/Holegots/.pyenv/shims:/usr/local/opt/icu4c/sbin:/usr/local/opt/icu4c/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/Holegots/.local/share/solana/install/active_release/bin:/Users/Holegots/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/Holegots/.orbstack/bin:/Applications/Obsidian.app/Contents/MacOS:/Users/Holegots/.spicetify:/Users/Holegots/go/bin:/Applications/Codex.app/Contents/Resources npm run docs:build