### PR TITLE
[codex] Add provider loop config projection

### DIFF
--- a/src/provider-loop-config.mts
+++ b/src/provider-loop-config.mts
@@ -1,0 +1,102 @@
+import {
+  type CredentialSource,
+  credentialSourcesForProjection,
+  type DescriptorValidationIssue,
+  PROVIDER_LOOP_DESCRIPTORS,
+  type ProviderLoopDescriptorDraft,
+  redactSecretLikeText,
+  validateProviderLoopDescriptors,
+} from './provider-loop-descriptors.mjs'
+
+export interface ProviderLoopConfigProjection {
+  readonly id: string
+  readonly displayName: string
+  readonly status: string
+  readonly providerFamily: string
+  readonly loopId: string
+  readonly eventFidelity: string
+  readonly approvalFidelity: string
+  readonly supportsSteer: boolean
+  readonly supportsInterrupt: boolean
+  readonly supportsResume: boolean
+  readonly allowedCredentialSources: readonly CredentialSource[]
+  readonly gatewayPolicy: string
+  readonly complianceNotes: readonly string[]
+}
+
+export interface ProviderLoopConfigProjectionResult {
+  readonly providers: readonly ProviderLoopConfigProjection[]
+  readonly issues: readonly DescriptorValidationIssue[]
+}
+
+interface ProjectableProviderLoopDescriptor extends ProviderLoopDescriptorDraft {
+  readonly id: string
+  readonly displayName: string
+  readonly status: string
+  readonly providerFamily: string
+  readonly gatewayPolicy: string
+  readonly loopId: string
+  readonly eventFidelity: string
+  readonly approvalFidelity: string
+  readonly supportsSteer: boolean
+  readonly supportsInterrupt: boolean
+  readonly supportsResume: boolean
+  readonly allowedCredentialSources: readonly string[]
+  readonly complianceNotes: readonly string[]
+}
+
+export function projectProviderLoopConfig(
+  descriptors: readonly ProviderLoopDescriptorDraft[] = PROVIDER_LOOP_DESCRIPTORS,
+): ProviderLoopConfigProjectionResult {
+  return {
+    providers: descriptors.flatMap((descriptor) => projectDescriptor(descriptor)),
+    issues: validateProviderLoopDescriptors(descriptors),
+  }
+}
+
+function projectDescriptor(
+  descriptor: ProviderLoopDescriptorDraft,
+): readonly ProviderLoopConfigProjection[] {
+  if (!isProjectableDescriptor(descriptor)) return []
+  return [
+    {
+      id: safeText(descriptor.id),
+      displayName: safeText(descriptor.displayName),
+      status: safeText(descriptor.status),
+      providerFamily: safeText(descriptor.providerFamily),
+      loopId: safeText(descriptor.loopId),
+      eventFidelity: safeText(descriptor.eventFidelity),
+      approvalFidelity: safeText(descriptor.approvalFidelity),
+      supportsSteer: descriptor.supportsSteer,
+      supportsInterrupt: descriptor.supportsInterrupt,
+      supportsResume: descriptor.supportsResume,
+      allowedCredentialSources: credentialSourcesForProjection(descriptor),
+      gatewayPolicy: safeText(descriptor.gatewayPolicy),
+      complianceNotes: descriptor.complianceNotes.map(safeText),
+    },
+  ]
+}
+
+function isProjectableDescriptor(
+  descriptor: ProviderLoopDescriptorDraft,
+): descriptor is ProjectableProviderLoopDescriptor {
+  return (
+    typeof descriptor.id === 'string' &&
+    typeof descriptor.displayName === 'string' &&
+    typeof descriptor.status === 'string' &&
+    typeof descriptor.providerFamily === 'string' &&
+    typeof descriptor.gatewayPolicy === 'string' &&
+    typeof descriptor.loopId === 'string' &&
+    typeof descriptor.eventFidelity === 'string' &&
+    typeof descriptor.approvalFidelity === 'string' &&
+    typeof descriptor.supportsSteer === 'boolean' &&
+    typeof descriptor.supportsInterrupt === 'boolean' &&
+    typeof descriptor.supportsResume === 'boolean' &&
+    Array.isArray(descriptor.allowedCredentialSources) &&
+    Array.isArray(descriptor.complianceNotes)
+  )
+}
+
+function safeText(value: string): string {
+  return redactSecretLikeText(value)
+}

--- a/src/provider-loop-config.mts
+++ b/src/provider-loop-config.mts
@@ -50,7 +50,7 @@ export function projectProviderLoopConfig(
 ): ProviderLoopConfigProjectionResult {
   return {
     providers: descriptors.flatMap((descriptor) => projectDescriptor(descriptor)),
-    issues: validateProviderLoopDescriptors(descriptors),
+    issues: validateProviderLoopDescriptors(descriptors).map(projectValidationIssue),
   }
 }
 
@@ -99,4 +99,13 @@ function isProjectableDescriptor(
 
 function safeText(value: string): string {
   return redactSecretLikeText(value)
+}
+
+function projectValidationIssue(issue: DescriptorValidationIssue): DescriptorValidationIssue {
+  return {
+    descriptorId: safeText(issue.descriptorId),
+    field: issue.field,
+    code: issue.code,
+    message: safeText(issue.message),
+  }
 }

--- a/test/provider-loop-config.test.mts
+++ b/test/provider-loop-config.test.mts
@@ -80,3 +80,36 @@ test('provider loop config projection redacts secret-like compliance notes', () 
     ['secret-like-value'],
   )
 })
+
+test('provider loop config projection redacts secret-like validation issues', () => {
+  const projected = projectProviderLoopConfig([
+    {
+      id: 'ANTHROPIC_API_KEY=sk-ant-fake000000000000000000000000000000',
+      displayName: 'Invalid Secret Provider',
+      status: 'experimental',
+      providerFamily: 'anthropic',
+      allowedCredentialSources: ['token=secret000000000000000000000000000000'],
+      gatewayPolicy: 'none',
+      loopId: 'invalid-secret-loop',
+      eventFidelity: 'transcript',
+      approvalFidelity: 'none',
+      supportsSteer: false,
+      supportsInterrupt: false,
+      supportsResume: false,
+      complianceNotes: ['fake descriptor for projection tests only'],
+      unsupportedCredentialSources: ['private-proxy'],
+    },
+  ])
+
+  assert.deepEqual(
+    projected.issues.map((issue) => issue.descriptorId),
+    ['ANTHROPIC_API_KEY=[redacted]', 'ANTHROPIC_API_KEY=[redacted]'],
+  )
+  assert.deepEqual(
+    projected.issues.map((issue) => issue.message),
+    [
+      'field contains a secret-like value',
+      'token=[redacted] is not a supported credential source label',
+    ],
+  )
+})

--- a/test/provider-loop-config.test.mts
+++ b/test/provider-loop-config.test.mts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { projectProviderLoopConfig } from '../src/provider-loop-config.mjs'
+
+test('provider loop config projection exposes the inert public descriptor shape', () => {
+  const projected = projectProviderLoopConfig()
+
+  assert.deepEqual(
+    projected.providers.map((provider) => provider.id),
+    ['claude-code', 'codex'],
+  )
+  assert.deepEqual(projected.issues, [])
+  assert.deepEqual(Object.keys(projected.providers[0] ?? {}).sort(), [
+    'allowedCredentialSources',
+    'approvalFidelity',
+    'complianceNotes',
+    'displayName',
+    'eventFidelity',
+    'gatewayPolicy',
+    'id',
+    'loopId',
+    'providerFamily',
+    'status',
+    'supportsInterrupt',
+    'supportsResume',
+    'supportsSteer',
+  ])
+})
+
+test('provider loop config projection filters unsupported credential labels', () => {
+  const projected = projectProviderLoopConfig([
+    {
+      id: 'test-provider',
+      displayName: 'Test Provider',
+      status: 'experimental',
+      providerFamily: 'anthropic',
+      allowedCredentialSources: ['user-api-key', 'personal-session', 'browser-cookie'],
+      gatewayPolicy: 'none',
+      loopId: 'test-loop',
+      eventFidelity: 'transcript',
+      approvalFidelity: 'none',
+      supportsSteer: false,
+      supportsInterrupt: false,
+      supportsResume: false,
+      complianceNotes: ['fake descriptor for projection tests only'],
+      unsupportedCredentialSources: ['personal-session', 'browser-cookie'],
+    },
+  ])
+
+  assert.deepEqual(projected.providers[0]?.allowedCredentialSources, ['user-api-key'])
+  assert.deepEqual(
+    projected.issues.map((issue) => issue.code),
+    ['unsupported-credential-source', 'unsupported-credential-source'],
+  )
+})
+
+test('provider loop config projection redacts secret-like compliance notes', () => {
+  const projected = projectProviderLoopConfig([
+    {
+      id: 'secret-provider',
+      displayName: 'Secret Provider',
+      status: 'experimental',
+      providerFamily: 'anthropic',
+      allowedCredentialSources: ['organization-gateway'],
+      gatewayPolicy: 'official-or-organization-managed',
+      loopId: 'secret-loop',
+      eventFidelity: 'message-level',
+      approvalFidelity: 'limited',
+      supportsSteer: false,
+      supportsInterrupt: true,
+      supportsResume: false,
+      complianceNotes: ['fake note token=secret000000000000000000000000000000'],
+      unsupportedCredentialSources: ['private-proxy'],
+    },
+  ])
+
+  assert.deepEqual(projected.providers[0]?.complianceNotes, ['fake note token=[redacted]'])
+  assert.deepEqual(
+    projected.issues.map((issue) => issue.code),
+    ['secret-like-value'],
+  )
+})


### PR DESCRIPTION
## Summary

- add a pure read-only provider loop config projection helper over the merged descriptor data
- expose only inert public fields: ids, display names, provider/loop ids, status, fidelity values, feature booleans, sanitized allowed credential source labels, gateway policy, and redacted compliance notes
- add focused tests proving unsupported personal-session/browser-cookie labels are not projected as allowed and fake secret-like notes are redacted

## Scope

This is one small Phase 2 helper/export slice. It does not wire the projection into `src/server.mts`, does not change runtime execution, auth flows, dependencies, docs wording, Rust code, or protocol behavior.

## Validation

All commands were run through Node 24 via `npx -y -p node@24 -c ...` from `origin/main` at `2c2b5f8` or later.

- `npm run build && node --test dist/test/provider-loop-config.test.mjs`
- `npm test`
- `npm run typecheck`
- `npm run check` (exits 0; reports pre-existing warnings outside this slice)
- `npm run docs:build`
- `git diff --check`

## Follow-up

Next slice can choose a read-only app-visible surface, likely `config/read`, and include adapter-level tests for the exact inert response shape without changing runtime dispatch.