### PR TITLE
[codex] Expose provider loop config in config/read

### DIFF
--- a/src/server.mts
+++ b/src/server.mts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { listClaudeHooks, listClaudeSkills } from './claude-capabilities.mjs'
 import { callMcpTool, listMcpServerStatuses, readMcpConfig, readMcpResource } from './mcp.mjs'
+import { projectProviderLoopConfig } from './provider-loop-config.mjs'
 import {
   addedFileDiff,
   asRecord,
@@ -2417,6 +2418,7 @@ export class CodexClaudeAppServer {
         analytics: this.configOverrides.analytics ?? null,
         apps: this.configOverrides.apps ?? null,
         model_providers: this.exposedModelProviders(),
+        provider_loop_config: projectProviderLoopConfig(),
       },
       origins: {
         model_provider: configLayerMetadata(),

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -10,6 +10,7 @@ import { join, resolve } from 'node:path'
 import { Duplex } from 'node:stream'
 import test from 'node:test'
 import WebSocket from 'ws'
+import type { ProviderLoopConfigProjectionResult } from '../src/provider-loop-config.mjs'
 
 const adapter = resolve('dist/src/adapter.mjs')
 const shim = resolve('scripts/codex-shim')
@@ -434,6 +435,25 @@ test('model/list exposes Claude model aliases and Codex-safe reasoning efforts',
     assert.equal(config.result.config.model_provider, 'claude-code')
     assert.equal(config.result.config.model_providers['claude-code'].name, 'Claude Code')
     assert.equal(config.result.config.model_providers['claude-code'].requires_openai_auth, false)
+    const providerLoopConfig = config.result.config
+      .provider_loop_config as ProviderLoopConfigProjectionResult
+    assert.deepEqual(
+      providerLoopConfig.providers.map((provider) => provider.id),
+      ['claude-code', 'codex'],
+    )
+    assert.deepEqual(providerLoopConfig.issues, [])
+    const claudeCodeProvider = providerLoopConfig.providers.find(
+      (provider) => provider.id === 'claude-code',
+    )
+    assert.ok(claudeCodeProvider)
+    assert.equal(claudeCodeProvider.loopId, 'native-claude-code-sdk')
+    assert.equal(claudeCodeProvider.providerFamily, 'anthropic')
+    assert.equal(claudeCodeProvider.status, 'stable')
+    assert.equal(claudeCodeProvider.supportsSteer, true)
+    const allowedCredentialSources = new Set<string>(claudeCodeProvider.allowedCredentialSources)
+    assert.equal(allowedCredentialSources.has('user-api-key'), true)
+    assert.equal(allowedCredentialSources.has('personal-session'), false)
+    assert.equal(allowedCredentialSources.has('browser-cookie'), false)
 
     proc.stdin.write(json({ id: 7, method: 'account/read', params: {} }))
     const account = await reader.nextResponse(7)


### PR DESCRIPTION
## Summary
- expose the existing sanitized provider loop projection as `config.provider_loop_config` in `config/read`
- add adapter-level stdio assertions that built-in provider descriptors are visible and unsupported credential labels are not allowed

## Verification
- `npx -y -p node@24 -c 'npm run build && node --test --test-name-pattern "model/list exposes Claude model aliases and Codex-safe reasoning efforts" dist/test/adapter.test.mjs'`\n- `npx -y -p node@24 -c 'npm test'`\n- `npx -y -p node@24 -c 'npm run typecheck'`\n- `npx -y -p node@24 -c 'npm run check'` (exits 0; existing warnings remain in untouched files)\n- `npx -y -p node@24 -c 'npm run docs:build'`\n- `git diff --check`\n\n## Scope\n- read-only config projection only\n- no runtime dispatch, auth, dependency, docs, Rust, or provider descriptor changes\n\n## Phase 2 follow-up\n- decide whether a later app/status surface should include descriptor issue counts or health metadata, still sourced from the sanitized projection