### PR TITLE
[codex] Add initial changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,4 +77,3 @@ versioning or publishing metadata.
 - No support is included for personal subscription sharing, credential pooling,
   browser cookie/session-token reuse, private provider endpoints, or provider
   bypass behavior.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable public-facing changes for Claude Codex Adapter are summarized here.
+The project is still private in `package.json`; this file tracks release notes
+for maintainers preparing the next public release and does not change package
+versioning or publishing metadata.
+
+## Unreleased
+
+### App-server and protocol compatibility
+
+- Updated the adapter to advertise Codex app-server protocol v2 compatibility at
+  the current pinned Codex CLI compatibility version, while keeping a
+  `claude-codex` suffix so hosts can distinguish the adapter from upstream
+  Codex.
+- Expanded Codex App Remote coverage across thread lifecycle, turn envelopes,
+  item streaming, approvals, MCP status, fuzzy file search sessions, Claude
+  skills/hooks, and `thread/turns/list` item views.
+- Kept compatibility-only account, plugin, marketplace, realtime, and other
+  OpenAI-specific surfaces inert or schema-shaped where Claude Code has no
+  equivalent.
+
+### Provider and multi-agent boundaries
+
+- Added the provider and multi-agent loop boundaries RFC to separate runtime
+  backends, provider metadata, agent-loop fidelity, credential ownership, and
+  subscription/entitlement boundaries.
+- Added static provider/agent-loop descriptors with validation for allowed and
+  unsupported credential source labels.
+- Added sanitized provider-loop projection helpers and exposed the read-only
+  `config.provider_loop_config` field through `config/read`.
+- Added tests proving built-in descriptors validate cleanly, unsupported
+  credential labels are not projected as allowed, and secret-like descriptor
+  text is redacted from public projection results.
+
+### Rust-first protocol groundwork
+
+- Added the Rust-first runtime boundaries RFC, keeping the TypeScript
+  app-server adapter as the shipping runtime path while defining incremental
+  Rust protocol, transport, store, and launcher boundaries.
+- Added an experimental Rust workspace scaffold and protocol crate with
+  representative Codex app-server JSON fixtures.
+- Added Rust parse/reserialize tests for the covered fixtures.
+- Added a pinned fixture drift check against the configured Codex CLI version
+  and made it part of CI alongside `cargo test --workspace`.
+
+### Release readiness and compliance docs
+
+- Added open-source compliance documentation and release-readiness reference
+  material for maintainers and reviewers.
+- Documented the current shippable baseline: TypeScript remains the production
+  path; Rust pieces are opt-in protocol boundary work; provider/loop descriptors
+  are read-only metadata, not runtime dispatch.
+- Documented supported credential ownership models: local user-provided API
+  keys, official cloud-provider credential chains, organization-managed
+  gateways, and local CLI auth for same-host user-directed execution.
+- Documented unsupported credential models, including personal subscription
+  sharing, browser cookie/session-token reuse, private provider endpoints,
+  bypass guidance, and credential redistribution.
+
+### Validation and release gates
+
+- Default CI runs Biome checks, TypeScript typechecking, the Node test suite,
+  Rust workspace tests, and the pinned Rust protocol fixture drift gate.
+- Documentation changes should run `npm run docs:build`.
+- Credentialed smoke and acceptance checks remain opt-in and must use
+  credentials already owned by the local user or organization on the host.
+
+### Still experimental or not yet included
+
+- No Rust production runtime, transport, store, provider execution path, or
+  default-on Rust launcher is included.
+- No executable new provider loop is included beyond the existing runtime
+  backends.
+- No broad runtime dispatch rewrite is included.
+- No new credential collection model is included.
+- No support is included for personal subscription sharing, credential pooling,
+  browser cookie/session-token reuse, private provider endpoints, or provider
+  bypass behavior.
+


### PR DESCRIPTION
## Summary
- add root `CHANGELOG.md` with an `Unreleased` next-release section
- group merged work by app-server/protocol compatibility, provider/multi-agent boundaries, Rust-first groundwork, release-readiness/compliance docs, and validation gates
- explicitly call out still-experimental/not-included areas without changing package version or publishing metadata

## Verification
- `git diff --check`
- `npm run docs:build`
- `npm run check` (exits 0; existing unrelated warnings remain in source/test/script files)

## Scope
- docs-only
- no runtime, tests, Rust, dependency, package version, CI, generated artifact, auth, or provider behavior changes

## Remaining release/versioning gaps
- decide the public release tag/version/date when the release is actually cut
- optionally add docs-site navigation for the changelog if maintainers want it visible in the published docs