### PR TITLE
Clarify open-source release positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Docs](https://github.com/fuergaosi233/claude-codex/actions/workflows/deploy-docs.yml/badge.svg)](https://fuergaosi233.github.io/claude-codex/)
 [![Node](https://img.shields.io/badge/node-%3E%3D24-brightgreen)](https://nodejs.org)
 
-Remote-mode adapter that lets the **Codex desktop app** talk to **Claude Code**
-through the native Codex `app-server` protocol.
+Production TypeScript adapter that lets the **Codex desktop app** talk to
+**Claude Code** through the native Codex `app-server` protocol in Remote mode.
 
 Codex App still runs its normal SSH version probe, bootstrap, and `app-server
 proxy` flow — but `codex app-server` is handled by this adapter instead of the
@@ -52,8 +52,35 @@ Codex App ──SSH──▶ login shell ──▶ codex (shim, earlier in PATH)
 
 Agent text and reasoning stream into the conversation; `Bash` becomes command
 approvals; `Edit`/`Write`/`MultiEdit` become file-change approvals with live
-diffs. Backends are pluggable (default in-process Agent SDK, plus `agent-http`,
-`agentapi`, `claude-p`, and native `codex` passthrough).
+diffs. Runtime selection maps only to existing backend paths today: default
+in-process Claude Agent SDK, `agent-http`, `agentapi`, `claude-p`, `codex-proxy`,
+and `mock`.
+
+## Current release boundaries
+
+- **Production path:** the TypeScript app-server adapter remains the shipping
+  path for Codex desktop Remote mode and Claude Code.
+- **Rust-first work:** RFCs, a workspace scaffold, protocol fixtures, parse /
+  reserialize tests, and pinned fixture drift checks are present. Rust does not
+  replace the production runtime, transport, store, or launcher yet.
+- **Provider and agent-loop work:** descriptors, sanitized `config/read`
+  projection, and explicit provider/loop selection are implemented. Selection
+  is metadata and routing for known descriptors only; it maps to existing
+  runtime backends and does not add a new executable provider loop.
+- **Credential model:** use local user-owned API keys, official cloud-provider
+  credential chains, local CLI auth on the same host, or organization-managed
+  gateways that own billing, policy, audit, and provider compliance.
+- **Unsupported:** personal subscription pooling, browser cookie or session-token
+  reuse, credential sharing, private endpoint use, provider bypass behavior, and
+  claims of unavailable entitlements.
+- **Release checks:** CI runs `npm run check`, `npm run typecheck`, `npm test`,
+  `cargo test --workspace`, and the pinned Rust fixture drift check. Docs changes
+  should run `npm run docs:build`; credentialed smoke and acceptance checks stay
+  opt-in with user- or organization-owned credentials.
+
+See the
+**[release readiness reference](https://fuergaosi233.github.io/claude-codex/reference/release-readiness)**
+for the verification matrix and reviewer checklist.
 
 ## Documentation
 
@@ -65,6 +92,7 @@ diffs. Backends are pluggable (default in-process Agent SDK, plus `agent-http`,
 | Configuration | <https://fuergaosi233.github.io/claude-codex/guide/configuration> |
 | Backends | <https://fuergaosi233.github.io/claude-codex/guide/backends> |
 | Capability matrix | <https://fuergaosi233.github.io/claude-codex/reference/capability-matrix> |
+| Release readiness | <https://fuergaosi233.github.io/claude-codex/reference/release-readiness> |
 | Contributing / toolchain | <https://fuergaosi233.github.io/claude-codex/contributing> |
 | Security policy | [SECURITY.md](SECURITY.md) |
 | Safe examples | [examples/](examples/) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: Claude Codex Adapter
   text: Claude Code inside the Codex app
-  tagline: A remote-mode adapter that speaks the native Codex app-server protocol, so the Codex desktop app drives Claude Code over your normal SSH Remote flow.
+  tagline: A production TypeScript adapter that speaks the native Codex app-server protocol, so the Codex desktop app drives Claude Code over your normal SSH Remote flow.
   actions:
     - theme: brand
       text: Get started
@@ -24,8 +24,11 @@ features:
     title: Claude Code turns
     details: Agent text and reasoning stream into the conversation; Bash becomes command approvals; Edit/Write/MultiEdit become file-change approvals with live diffs.
   - icon: 🔁
-    title: Pluggable backends
-    details: Default in-process Agent SDK, plus agent-http (Channels), agentapi, claude-p, and native codex passthrough — switched per host with claude-codex-mode.
+    title: Explicit existing backends
+    details: >-
+      Provider and loop selection is sanitized metadata that maps known
+      descriptors to existing runtime paths: Agent SDK, agent-http, agentapi,
+      claude-p, codex-proxy, and mock.
   - icon: 📦
     title: Zero-toolchain deploy
     details: Ships compiled ESM .mjs, so a remote host needs only Node 24. Dev runs straight from TypeScript with tsx.
@@ -38,6 +41,23 @@ Unix-socket daemon, and `app-server proxy`) and bridges each Codex request to a
 Claude Code runtime. Thread lifecycle, streaming, approvals, MCP, and remote
 filesystem/command utilities are all backed by real runtime behavior.
 
+The current release path is intentionally narrow. TypeScript remains the
+production runtime. Rust-first work is present as RFCs, an experimental protocol
+crate, fixtures, parse/reserialize tests, and a pinned fixture drift gate, but it
+does not replace the runtime, transport, store, or launcher. Provider and
+agent-loop work exposes descriptors, sanitized config projection, and explicit
+selection for known descriptors only; it does not add a new provider runtime,
+auth system, gateway, subscription model, or multi-agent orchestrator.
+
+Credentials should be supplied by the local user or organization through API
+keys, official cloud-provider credential chains, same-host local CLI auth, or an
+approved organization gateway. The project does not support personal
+subscription pooling, browser cookie/session-token reuse, credential sharing,
+private endpoints, provider bypasses, or claims of unavailable entitlements.
+Release checks include CI `check`, `cargo-test`, TypeScript tests, the pinned
+Rust fixture drift gate, docs build for docs changes, and opt-in credentialed
+smoke or acceptance checks.
+
 ```bash
 npm install
 npm run build        # tsc -> dist/ (production artifact)
@@ -47,6 +67,9 @@ npm run doctor       # environment self-check
 
 Then install the [`codex` shim](/guide/deployment) on the remote host and add a
 Remote connection in the Codex App. See **[Getting started](/guide/getting-started)**.
+
+For release gates and reviewer expectations, see
+**[Release readiness](/reference/release-readiness)**.
 
 ::: tip Requires Node.js 24+
 The thread store uses `node:sqlite`, which is only stable (unflagged) on Node 24.


### PR DESCRIPTION
## Summary
- tighten the README introduction around the production TypeScript Remote-mode adapter path
- add a compact current release boundaries section covering Rust-first, provider/loop, credential, unsupported behavior, and release checks
- update the docs homepage with the same bounded positioning and a release readiness link

## Verification
- npm run docs:build
- npm run check (exits 0; existing unrelated warnings remain)
- git diff --check origin/main...HEAD

## Scope
Docs-only: README.md and docs/index.md. No runtime, tests, Rust, dependency, CI, package metadata, generated artifact, auth, or provider behavior changes.