### PR TITLE
feat: add /workflows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ diffs. Runtime selection maps only to existing backend paths today: default
 in-process Claude Agent SDK, `agent-http`, `agentapi`, `claude-p`, `codex-proxy`,
 and `mock`.
 
+### `/workflows` compatibility
+
+With the native Claude Agent SDK backend, `/workflows <task>` is translated to Claude's
+`ultracode:` workflow trigger. Workflow task events are exposed as Codex-native reviewable
+Subagent threads. A bare `/workflows` lists workflow runs recorded in the current Codex thread.
+
+This compatibility layer is specific to the native Claude Agent SDK backend. Alternate HTTP,
+agentapi, and `claude -p` backends receive no workflow event bridge. Interactive workflow
+management actions such as pause, resume, stop, and save are not implemented.
+
 ## Current release boundaries
 
 - **Production path:** the TypeScript app-server adapter remains the shipping

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ This compatibility layer is specific to the native Claude Agent SDK backend. Alt
 agentapi, and `claude -p` backends receive no workflow event bridge. Interactive workflow
 management actions such as pause, resume, stop, and save are not implemented.
 
+When Codex Full Access is selected, the adapter keeps Claude in its standard permission mode and
+auto-allows permission requests through the existing Codex bridge. This avoids Relay's refusal of
+dangerous permission bypass outside a recognized container sandbox while preserving a zero-prompt
+Full Access turn. Operators can still opt into native SDK bypass explicitly with
+`CLAUDE_CODEX_PERMISSION_MODE=bypassPermissions` in an appropriately isolated environment.
+
 ## Current release boundaries
 
 - **Production path:** the TypeScript app-server adapter remains the shipping

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ and `mock`.
 
 With the native Claude Agent SDK backend, `/workflows <task>` is translated to Claude's
 `ultracode:` workflow trigger. Workflow task events are exposed as Codex-native reviewable
-Subagent threads. A bare `/workflows` lists workflow runs recorded in the current Codex thread.
+Subagent threads. While a local workflow runs, the adapter tails its journal and projects each
+inner agent as a separate `spawnAgent` → `wait` → `closeAgent` lifecycle; runtimes without journal
+metadata fall back to one aggregate workflow agent when the workflow reaches a terminal state.
+A bare `/workflows` lists workflow runs
+recorded in the current Codex thread.
 
 This compatibility layer is specific to the native Claude Agent SDK backend. Alternate HTTP,
 agentapi, and `claude -p` backends receive no workflow event bridge. Interactive workflow

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ and `mock`.
 With the native Claude Agent SDK backend, `/workflows <task>` is translated to Claude's
 `ultracode:` workflow trigger. Workflow task events are exposed as Codex-native reviewable
 Subagent threads. While a local workflow runs, the adapter tails its journal and projects each
-inner agent as a separate `spawnAgent` → `wait` → `closeAgent` lifecycle; runtimes without journal
-metadata fall back to one aggregate workflow agent when the workflow reaches a terminal state.
+inner agent through Codex's native `subAgentActivity` lifecycle (with `completed` sent only to
+clients that advertise it) plus `spawnAgent`/`wait` tool state; runtimes without journal metadata
+fall back to one aggregate workflow agent when the workflow reaches a terminal state.
 A bare `/workflows` lists workflow runs
 recorded in the current Codex thread.
 

--- a/docs/reference/capability-matrix.md
+++ b/docs/reference/capability-matrix.md
@@ -44,7 +44,7 @@ Agent SDK sidecar; runtime selection is pluggable. Status legend: **Supported**,
 | File edit approval | Supported | Edit/Write/MultiEdit → Codex fileChange items with approval + diff updates. |
 | Bash output | Supported | Forwarded as command output on completion (SDK has no incremental tool-output streaming). |
 | Generic Claude tools | Supported | Non-command/file tools → mcpToolCall items under the `claude-code` pseudo server. |
-| Subagent (Task) | Supported | Task spawns an ephemeral child thread and emits Codex's native 3-stage timeline (`spawnAgent` → `wait` → `closeAgent`); inner events are hidden, the final result lands as one agentMessage on the child thread. |
+| Subagent (Task) | Supported | Task spawns an ephemeral child thread and emits native `subAgentActivity` lifecycle events (capability-gated `completed`) plus `spawnAgent`/`wait` tool state; inner events are hidden, and the final result lands as one agentMessage on the child thread. |
 | Ephemeral / threadSource | Supported | `ephemeral: true` threads (title-gen, memory-consolidation, subagents) persist but are excluded from `thread/list` unless `includeEphemeral: true`. `threadSource` round-trips. |
 | Claude side events | Supported | rate_limit / hook / subagent / compaction events summarized into structured notice lines. |
 | Review mode | Supported (text) | `review/start` creates an in-progress review turn and routes the prompt through Claude. No native guardian finding items. |

--- a/src/adapter.mts
+++ b/src/adapter.mts
@@ -109,6 +109,8 @@ async function main(): Promise<void> {
   debugLog('adapter.start', { pid: process.pid, listen, isUnixDaemon })
 
   const onMessage = server.handle.bind(server)
+  const normalized = normalizeListenUrl(listen)
+  const isStdio = normalized === 'stdio://'
 
   // When the Codex client (app-server proxy) disconnects, a `unix://` daemon
   // would otherwise linger forever and keep its Claude runtime sidecar alive.
@@ -154,10 +156,17 @@ async function main(): Promise<void> {
   const onClose = (peer: RpcPeer) => {
     activePeers = Math.max(0, activePeers - 1)
     server.closePeer(peer)
+    if (isStdio) {
+      // A stdio peer is the process lifetime. If Codex closes its pipe during
+      // reconnect, stop the runtime and terminalize all child turns before the
+      // process exits; otherwise the old in-memory subagent can remain active
+      // while the replacement adapter is already serving the same database.
+      void shutdown('stdioClose')
+      return
+    }
     armIdleExit()
   }
 
-  const normalized = normalizeListenUrl(listen)
   if (normalized === 'stdio://') {
     startStdioTransport(onMessage, onClose)
     return

--- a/src/adapter.mts
+++ b/src/adapter.mts
@@ -77,13 +77,16 @@ async function main(): Promise<void> {
   }
 
   const store = new SessionStore()
-  if (isUnixDaemon) {
-    const recovered = store.recoverStaleInProgressTurns()
-    if (recovered > 0) {
-      process.stderr.write(
-        `[claude-codex-adapter] recovered ${recovered} stale in-progress turn(s)\n`,
-      )
-    }
+  // Codex cc normally launches the app-server over stdio, so a crashed or
+  // force-quit adapter leaves its last turn persisted as `inProgress`. The
+  // next stdio process is the recovery boundary just like the unix daemon;
+  // only recovering unix transports leaves the App's subagent view stuck on
+  // "loading" forever after a restart.
+  const recovered = store.recoverStaleInProgressTurns()
+  if (recovered > 0) {
+    process.stderr.write(
+      `[claude-codex-adapter] recovered ${recovered} stale in-progress turn(s)\n`,
+    )
   }
   const runtime = createRuntime()
   const server = new CodexClaudeAppServer(store, runtime)

--- a/src/mock-runtime.mts
+++ b/src/mock-runtime.mts
@@ -273,6 +273,7 @@ export class MockRuntime implements ClaudeRuntime {
         toolName: 'Task',
         input: { description: 'mock subagent', prompt: 'investigate' },
       })
+      await sleep(75)
       await handlers.onEvent({
         type: 'text_delta',
         delta: 'subagent thinking aloud (should be hidden)',

--- a/src/mock-runtime.mts
+++ b/src/mock-runtime.mts
@@ -248,6 +248,18 @@ export class MockRuntime implements ClaudeRuntime {
       return
     }
 
+    if (/orphan subagent check/i.test(context.prompt)) {
+      const taskId = `task-${Date.now()}`
+      await handlers.onEvent({
+        type: 'tool_use',
+        toolUseId: taskId,
+        toolName: 'Task',
+        input: { description: 'orphaned mock subagent', prompt: 'investigate disconnect' },
+      })
+      await handlers.onEvent({ type: 'completed', success: true, result: 'missing tool result' })
+      return
+    }
+
     if (/subagent check/i.test(context.prompt)) {
       // Drive the subagent suppression contract: a Task tool_use opens the
       // subagent context, internal tool_use/text/tool_result are emitted but

--- a/src/native-runtime.mts
+++ b/src/native-runtime.mts
@@ -76,6 +76,7 @@ interface PendingTurn {
   structuredBuffer: string
   pendingUserMessage: null | { resolve: (v: { message: unknown }) => void }
   deferredResult: PendingTurnResult | null
+  workflowFailure: string | null
 }
 
 interface PendingTurnResult {
@@ -146,6 +147,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         structuredBuffer: '',
         pendingUserMessage: null,
         deferredResult: null,
+        workflowFailure: null,
       }
       this.turns.set(context.turnId, pending)
       // Kick off the receive loop in the background. We don't await it here
@@ -546,7 +548,18 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
       const knownState = pending.workflowTasks?.get(taskId)
       const hasWorkflowHint =
         isWorkflowBackgroundTask(message) || String(message.workflow_name ?? '').trim().length > 0
-      if (!knownState && !hasWorkflowHint) return
+      const sourceToolUseId = String(message.tool_use_id ?? '')
+      const hasPendingWorkflowLaunch = [...(pending.workflowLaunches?.values() ?? [])].some(
+        (launch) => launch.taskId === taskId,
+      )
+      const hasPendingWorkflowTool =
+        sourceToolUseId.length > 0 && pending.workflowToolUseIds?.has(sourceToolUseId) === true
+      // The SDK's task_notification shape does not require task_type or
+      // workflow_name. Once this turn has a matching launch/tool id, the task
+      // is already proven to be a Workflow and the terminal notification must
+      // not be discarded just because optional hints are absent.
+      if (!knownState && !hasWorkflowHint && !hasPendingWorkflowLaunch && !hasPendingWorkflowTool)
+        return
       if (pending.skippedWorkflowTaskIds?.has(taskId)) {
         this.discardDeferredWorkflowLaunches(pending, taskId, '')
         const hiddenState = pending.workflowTasks?.get(taskId)
@@ -576,7 +589,6 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         // projected state from the notification instead of dropping the only
         // terminal signal and leaving the parent deferred forever.
         state = this.ensureWorkflowTask(pending, taskId)
-        const sourceToolUseId = String(message.tool_use_id ?? '')
         if (sourceToolUseId && !state.toolUseId) state.toolUseId = sourceToolUseId
         state.workflowName = String(message.workflow_name ?? '').trim() || state.workflowName
         state.description = String(message.description ?? '').trim() || state.description
@@ -621,33 +633,41 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
       const trailer = usage
         ? `\n<usage>total_tokens: ${usage.totalTokens}\ntool_uses: ${usage.toolUses}\nduration_ms: ${usage.durationMs}</usage>`
         : ''
-      if (state.monitor && !state.aggregateStarted) {
-        await settlesWithin(state.monitor.flush(), WORKFLOW_TERMINAL_FLUSH_TIMEOUT_MS)
-        await state.monitor.drain(WORKFLOW_JOURNAL_SETTLE_TIMEOUT_MS)
-        const projectedBeforeStop = this.workflowProjectedAgentIds(pending, state)
-        if (state.monitor.startedCount > 0 || projectedBeforeStop.length > 0) {
-          state.terminal = true
+      const monitor = state.monitor
+      if (monitor && !state.aggregateStarted && !state.monitorFailed) {
+        await settlesWithin(monitor.flush(), WORKFLOW_TERMINAL_FLUSH_TIMEOUT_MS)
+        // onError can replace state.monitor while flush() is awaiting I/O.
+        // Continue through the aggregate fallback in that case; never
+        // dereference the mutable field after an await.
+        if (state.monitor === monitor && !state.monitorFailed) {
+          await monitor.drain(WORKFLOW_JOURNAL_SETTLE_TIMEOUT_MS)
         }
-        await state.monitor.stop()
-        const projectedAgentIds = this.workflowProjectedAgentIds(pending, state)
-        if (state.monitor.startedCount > 0 || projectedAgentIds.length > 0) {
-          state.terminal = true
-          await this.closeWorkflowAgentLifecycles(
-            pending,
-            state,
-            status === 'completed'
-              ? `Workflow completed before the individual transcript result became visible.\n${summary}`
-              : `Workflow ended before the agent published an individual result.\n${summary}`,
-            status !== 'completed',
-          )
-          pending.completedWorkflowTasks.add(toolUseId)
-          await pending.handlers.onEvent({
-            type: 'notice',
-            level: status === 'completed' ? 'info' : 'warning',
-            message: `${state.workflowName || `Workflow ${taskId}`}: ${summary}${trailer}`,
-          })
-          await this.finishDeferredResult(pending)
-          return
+        if (state.monitor === monitor && !state.monitorFailed) {
+          const projectedBeforeStop = this.workflowProjectedAgentIds(pending, state)
+          if (monitor.startedCount > 0 || projectedBeforeStop.length > 0) {
+            state.terminal = true
+          }
+          await monitor.stop()
+          const projectedAgentIds = this.workflowProjectedAgentIds(pending, state)
+          if (monitor.startedCount > 0 || projectedAgentIds.length > 0) {
+            state.terminal = true
+            await this.closeWorkflowAgentLifecycles(
+              pending,
+              state,
+              status === 'completed'
+                ? `Workflow completed before the individual transcript result became visible.\n${summary}`
+                : `Workflow ended before the agent published an individual result.\n${summary}`,
+              status !== 'completed',
+            )
+            pending.completedWorkflowTasks.add(toolUseId)
+            await pending.handlers.onEvent({
+              type: 'notice',
+              level: status === 'completed' ? 'info' : 'warning',
+              message: `${state.workflowName || `Workflow ${taskId}`}: ${summary}${trailer}`,
+            })
+            await this.finishDeferredResult(pending)
+            return
+          }
         }
       }
 
@@ -916,13 +936,15 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
       },
       onError: async (error) => {
         if (state.terminal) return
-        // Keep the task eligible for the aggregate fallback until Claude sends
-        // its terminal task_notification. This is important for security
-        // failures (for example a symlinked journal): the monitor is dead, but
-        // the task result can still close the visible Agent cleanly.
+        // Monitoring failures are terminal for the projected workflow. Record
+        // the failure now so a later successful SDK result cannot revive the
+        // task or leave the parent waiting for a journal that is no longer
+        // being observed.
+        const message = `Workflow monitoring failed: ${error.message}`
         state.monitorFailed = true
         state.monitor = null
-        const message = `Workflow monitoring failed: ${error.message}`
+        state.terminal = true
+        pending.workflowFailure ??= message
         await this.closeWorkflowAgentLifecycles(pending, state, message, true)
         await this.closeWorkflowAggregateLifecycle(pending, state, message, true)
         if (state.toolUseId) pending.workflowToolUseIds.delete(state.toolUseId)
@@ -932,8 +954,12 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
           message,
         })
         if (pending.deferredResult) {
-          state.terminal = true
           pending.completedWorkflowTasks.add(workflowTaskToolUseId(state.taskId))
+          pending.deferredResult = {
+            ...pending.deferredResult,
+            success: false,
+            resultText: pending.deferredResult.resultText ?? message,
+          }
           await this.finishDeferredResult(pending, true)
         }
       },
@@ -1099,8 +1125,9 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
   ): Promise<void> {
     if (pending.deferredResult || pending.resolved) return
     const subtype = String(message.subtype ?? '')
-    const success = subtype === 'success' && !message.is_error
-    const resultText = message.result == null ? null : String(message.result)
+    const success = subtype === 'success' && !message.is_error && pending.workflowFailure == null
+    const resultText =
+      pending.workflowFailure ?? (message.result == null ? null : String(message.result))
     const claudeSessionId = message.session_id == null ? null : String(message.session_id)
     const usage = (message.usage as Record<string, unknown>) || {}
     // Push usage + metrics before completed so server can roll them into the

--- a/src/native-runtime.mts
+++ b/src/native-runtime.mts
@@ -34,6 +34,7 @@ import type {
   UserInputQuestion,
 } from './types.mjs'
 import { newId } from './util.mjs'
+import { parseWorkflowCommand, workflowRuntimePrompt } from './workflow-command.mjs'
 
 type ClaudeSdk = typeof import('@anthropic-ai/claude-agent-sdk')
 
@@ -52,6 +53,7 @@ interface PendingTurn {
   // nested tool_use / text / thinking events should be hidden from the App
   // timeline until the matching tool_result closes the parent Task.
   activeSubagents: Set<string>
+  completedWorkflowTasks: Set<string>
   // Tool ids whose content_block_start we already saw — used to skip the
   // second delivery via AssistantMessage.content (the SDK ships every
   // ToolUseBlock twice; we keep only the AssistantMessage copy because
@@ -102,6 +104,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         streamedText: false,
         streamedThinking: false,
         activeSubagents: new Set(),
+        completedWorkflowTasks: new Set(),
         toolStartSeen: new Set(),
         structuredBuffer: '',
         pendingUserMessage: null,
@@ -132,8 +135,9 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
           (async function* () {
             yield {
               type: 'user',
-              message: { role: 'user', content: prompt },
+              message: { role: 'user', content: workflowRuntimePrompt(prompt) },
               parent_tool_use_id: null,
+              origin: { kind: 'human' },
             }
           })(),
         )
@@ -170,7 +174,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
   }
 
   private buildPromptIterable(context: RuntimeTurnContext): AsyncIterable<any> {
-    const text = context.prompt
+    const text = workflowRuntimePrompt(context.prompt)
     const images = context.imageInputs
     return (async function* () {
       if (!images || images.length === 0) {
@@ -180,6 +184,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
           type: 'user' as const,
           message: { role: 'user' as const, content: text },
           parent_tool_use_id: null,
+          origin: { kind: 'human' as const },
         }
         return
       }
@@ -203,6 +208,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         type: 'user' as const,
         message: { role: 'user' as const, content },
         parent_tool_use_id: null,
+        origin: { kind: 'human' as const },
       }
     })()
   }
@@ -237,6 +243,14 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
     // acceptEdits (no prompt for write/edit until something fails).
     const mode = derivePermissionMode(context.approvalPolicy, context.sandboxMode, context.planMode)
     opts.permissionMode = mode
+
+    if (parseWorkflowCommand(context.prompt)?.type === 'run') {
+      opts.settings = {
+        ...((opts.settings as Record<string, unknown> | undefined) ?? {}),
+        enableWorkflows: true,
+        workflowKeywordTriggerEnabled: true,
+      }
+    }
 
     // Per-tool approval round-trip with Codex App. We attach canUseTool in
     // every non-plan mode so we can also intercept AskUserQuestion (which
@@ -425,6 +439,48 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         type: 'notice',
         level: 'warning',
         message: `Permission denied for ${toolName}`,
+      })
+      return
+    }
+    if (subtype === 'task_started' && isWorkflowBackgroundTask(message)) {
+      const taskId = String(message.task_id ?? '')
+      if (!taskId || message.skip_transcript === true) return
+      const toolUseId = workflowTaskToolUseId(taskId)
+      if (pending.activeSubagents.has(toolUseId) || pending.completedWorkflowTasks.has(toolUseId))
+        return
+      pending.activeSubagents.add(toolUseId)
+      const workflowName = String(message.workflow_name ?? '').trim()
+      const description = String(message.description ?? '').trim()
+      const prompt = String(message.prompt ?? '').trim() || description || workflowName
+      await pending.handlers.onEvent({
+        type: 'tool_use',
+        toolUseId,
+        toolName: 'Agent',
+        input: {
+          description: workflowName ? `Workflow: ${workflowName}` : 'Workflow',
+          prompt,
+          subagent_type: 'workflow',
+        },
+      })
+      return
+    }
+    if (subtype === 'task_notification') {
+      const taskId = String(message.task_id ?? '')
+      if (!taskId) return
+      const toolUseId = workflowTaskToolUseId(taskId)
+      if (!pending.activeSubagents.delete(toolUseId)) return
+      pending.completedWorkflowTasks.add(toolUseId)
+      const status = String(message.status ?? '')
+      const summary = String(message.summary ?? '').trim() || `Workflow ${status || 'finished'}`
+      const usage = workflowTaskUsage(message.usage)
+      const trailer = usage
+        ? `\n<usage>total_tokens: ${usage.totalTokens}\ntool_uses: ${usage.toolUses}\nduration_ms: ${usage.durationMs}</usage>`
+        : ''
+      await pending.handlers.onEvent({
+        type: 'tool_result',
+        toolUseId,
+        content: `${summary}${trailer}`,
+        isError: status !== 'completed',
       })
     }
   }
@@ -652,6 +708,29 @@ function isSubagentTool(name: string): boolean {
   return (
     n === 'task' || n === 'agent' || n === 'subagent' || n === 'spawn_agent' || n === 'spawnagent'
   )
+}
+
+function isWorkflowBackgroundTask(message: Record<string, unknown>): boolean {
+  const taskType = String(message.task_type ?? '')
+  return taskType === 'local_workflow' || taskType === 'workflow'
+}
+
+function workflowTaskToolUseId(taskId: string): string {
+  return `workflow-task:${taskId}`
+}
+
+function workflowTaskUsage(value: unknown): {
+  totalTokens: number
+  toolUses: number
+  durationMs: number
+} | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const usage = value as Record<string, unknown>
+  const totalTokens = numberOrNull(usage.total_tokens)
+  const toolUses = numberOrNull(usage.tool_uses)
+  const durationMs = numberOrNull(usage.duration_ms)
+  if (totalTokens === null || toolUses === null || durationMs === null) return null
+  return { totalTokens, toolUses, durationMs }
 }
 
 function numberOrNull(value: unknown): number | null {

--- a/src/native-runtime.mts
+++ b/src/native-runtime.mts
@@ -237,12 +237,14 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
     if (context.outputFormat) opts.outputFormat = context.outputFormat
 
     // Codex App's pinned policies map onto Claude SDK's permissionMode. plan
-    // mode supersedes everything (Codex sends planMode:true via turn/start);
-    // approvalPolicy 'never' / sandbox 'danger-full-access' both mean "skip
-    // per-tool prompts" → bypassPermissions; 'on-failure' approximates
-    // acceptEdits (no prompt for write/edit until something fails).
+    // mode supersedes everything. Relay rejects the SDK's dangerous bypass
+    // flag outside a recognized container sandbox, so App-level Full Access
+    // stays in default mode and auto-allows through canUseTool below. An
+    // explicit env override can still opt into bypassPermissions.
+    const permissionModeOverride = configuredPermissionMode()
     const mode = derivePermissionMode(context.approvalPolicy, context.sandboxMode, context.planMode)
     opts.permissionMode = mode
+    if (mode === 'bypassPermissions') opts.allowDangerouslySkipPermissions = true
 
     if (parseWorkflowCommand(context.prompt)?.type === 'run') {
       opts.settings = {
@@ -252,14 +254,15 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
       }
     }
 
-    // Per-tool approval round-trip with Codex App. We attach canUseTool in
-    // every non-plan mode so we can also intercept AskUserQuestion (which
-    // needs to be bridged to the App's native request_user_input even when
-    // the user has chosen Full Access / bypassPermissions). In bypass modes
-    // the callback short-circuits non-AskUserQuestion tools to auto-allow,
-    // preserving the no-prompt behaviour.
-    if (mode !== 'plan') {
-      const autoAllow = mode === 'bypassPermissions' || mode === 'dontAsk'
+    // Per-tool approval round-trip with Codex App. In App-level Full Access,
+    // the bridge auto-allows every permission request without surfacing a UI
+    // prompt. Explicit SDK bypass omits the callback because Claude never calls
+    // it in that mode.
+    if (mode !== 'plan' && mode !== 'bypassPermissions') {
+      const appFullAccess =
+        permissionModeOverride === null &&
+        (context.approvalPolicy === 'never' || context.sandboxMode === 'danger-full-access')
+      const autoAllow = appFullAccess || mode === 'dontAsk'
       opts.canUseTool = this.makeCanUseTool(context, autoAllow)
     }
 
@@ -683,22 +686,34 @@ function derivePermissionMode(
   planMode: boolean,
 ): 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'auto' {
   // Env-level override always wins.
-  const envOverride = process.env.CLAUDE_CODEX_PERMISSION_MODE
-  if (
-    envOverride === 'default' ||
-    envOverride === 'acceptEdits' ||
-    envOverride === 'bypassPermissions' ||
-    envOverride === 'plan' ||
-    envOverride === 'dontAsk' ||
-    envOverride === 'auto'
-  ) {
-    return envOverride
-  }
+  const envOverride = configuredPermissionMode()
+  if (envOverride) return envOverride
   if (planMode) return 'plan'
-  if (sandboxMode === 'danger-full-access') return 'bypassPermissions'
-  if (approvalPolicy === 'never') return 'bypassPermissions'
+  if (sandboxMode === 'danger-full-access' || approvalPolicy === 'never') return 'default'
   if (approvalPolicy === 'on-failure') return 'acceptEdits'
   return 'default'
+}
+
+function configuredPermissionMode():
+  | 'default'
+  | 'acceptEdits'
+  | 'bypassPermissions'
+  | 'plan'
+  | 'dontAsk'
+  | 'auto'
+  | null {
+  const value = process.env.CLAUDE_CODEX_PERMISSION_MODE
+  if (
+    value === 'default' ||
+    value === 'acceptEdits' ||
+    value === 'bypassPermissions' ||
+    value === 'plan' ||
+    value === 'dontAsk' ||
+    value === 'auto'
+  ) {
+    return value
+  }
+  return null
 }
 
 // Subagent tool detection — same allowlist as Python's is_subagent_tool and

--- a/src/native-runtime.mts
+++ b/src/native-runtime.mts
@@ -35,6 +35,12 @@ import type {
 } from './types.mjs'
 import { newId } from './util.mjs'
 import { parseWorkflowCommand, workflowRuntimePrompt } from './workflow-command.mjs'
+import {
+  defaultWorkflowTranscriptRoots,
+  parseWorkflowLaunchInfo,
+  WorkflowJournalMonitor,
+  type WorkflowLaunchInfo,
+} from './workflow-subagents.mjs'
 
 type ClaudeSdk = typeof import('@anthropic-ai/claude-agent-sdk')
 
@@ -54,6 +60,11 @@ interface PendingTurn {
   // timeline until the matching tool_result closes the parent Task.
   activeSubagents: Set<string>
   completedWorkflowTasks: Set<string>
+  workflowToolUseIds: Set<string>
+  workflowLaunches: Map<string, WorkflowLaunchInfo>
+  workflowTranscriptRoots: string[]
+  skippedWorkflowTaskIds: Set<string>
+  workflowTasks: Map<string, WorkflowTaskState>
   // Tool ids whose content_block_start we already saw — used to skip the
   // second delivery via AssistantMessage.content (the SDK ships every
   // ToolUseBlock twice; we keep only the AssistantMessage copy because
@@ -64,6 +75,24 @@ interface PendingTurn {
   // text and emit only the final coerced JSON.
   structuredBuffer: string
   pendingUserMessage: null | { resolve: (v: { message: unknown }) => void }
+  deferredResult: PendingTurnResult | null
+}
+
+interface PendingTurnResult {
+  success: boolean
+  resultText: string | null
+  claudeSessionId: string | null
+}
+
+interface WorkflowTaskState {
+  taskId: string
+  toolUseId: string
+  workflowName: string
+  description: string
+  prompt: string
+  monitor: WorkflowJournalMonitor | null
+  aggregateStarted: boolean
+  terminal: boolean
 }
 
 interface PendingPermission {
@@ -75,6 +104,8 @@ interface PendingPermission {
 // content_block_delta envelope but distinguishes via delta.type.
 const STREAMED_TEXT = 'text'
 const STREAMED_THINKING = 'thinking'
+const WORKFLOW_TERMINAL_FLUSH_TIMEOUT_MS = 500
+const WORKFLOW_JOURNAL_SETTLE_TIMEOUT_MS = 3_000
 
 export class NativeClaudeRuntime implements ClaudeRuntime {
   private sdk: ClaudeSdk | null = null
@@ -105,9 +136,15 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         streamedThinking: false,
         activeSubagents: new Set(),
         completedWorkflowTasks: new Set(),
+        workflowToolUseIds: new Set(),
+        workflowLaunches: new Map(),
+        workflowTranscriptRoots: defaultWorkflowTranscriptRoots(process.env),
+        skippedWorkflowTaskIds: new Set(),
+        workflowTasks: new Map(),
         toolStartSeen: new Set(),
         structuredBuffer: '',
         pendingUserMessage: null,
+        deferredResult: null,
       }
       this.turns.set(context.turnId, pending)
       // Kick off the receive loop in the background. We don't await it here
@@ -149,6 +186,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
   async interrupt(threadId: string): Promise<void> {
     for (const pending of this.turns.values()) {
       if (pending.context.threadId === threadId) {
+        await this.stopWorkflowTasks(pending)
         pending.abort.abort()
         await pending.query.interrupt().catch(() => {})
       }
@@ -157,6 +195,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
 
   async stop(): Promise<void> {
     for (const pending of this.turns.values()) {
+      await this.stopWorkflowTasks(pending)
       pending.abort.abort()
     }
     this.turns.clear()
@@ -368,10 +407,15 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         await this.handleMessage(pending, message)
         if (pending.resolved) break
       }
+      if (!pending.resolved && pending.deferredResult) {
+        await this.finishDeferredResult(pending)
+        if (!pending.resolved) return
+      }
       // The async iterator finished without a 'result' message — treat as
       // successful empty turn (claude-agent-sdk does occasionally end without
       // a SDKResultMessage when interrupted cleanly).
       if (!pending.resolved) {
+        await this.stopWorkflowTasks(pending)
         pending.resolved = true
         this.turns.delete(context.turnId)
         try {
@@ -383,6 +427,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
       }
     } catch (err) {
       if (!pending.resolved) {
+        await this.stopWorkflowTasks(pending)
         pending.resolved = true
         this.turns.delete(context.turnId)
         const error = err instanceof Error ? err : new Error(String(err))
@@ -447,44 +492,149 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
     }
     if (subtype === 'task_started' && isWorkflowBackgroundTask(message)) {
       const taskId = String(message.task_id ?? '')
-      if (!taskId || message.skip_transcript === true) return
-      const toolUseId = workflowTaskToolUseId(taskId)
-      if (pending.activeSubagents.has(toolUseId) || pending.completedWorkflowTasks.has(toolUseId))
+      if (!taskId) return
+      const sourceToolUseId = String(message.tool_use_id ?? '')
+      if (message.skip_transcript === true) {
+        const skipped =
+          pending.skippedWorkflowTaskIds ?? (pending.skippedWorkflowTaskIds = new Set())
+        skipped.add(taskId)
+        this.discardDeferredWorkflowLaunches(pending, taskId, sourceToolUseId)
+        const hiddenState = pending.workflowTasks?.get(taskId)
+        if (hiddenState) {
+          hiddenState.terminal = true
+          await hiddenState.monitor?.stop()
+          await this.closeWorkflowAgentLifecycles(
+            pending,
+            hiddenState,
+            'Workflow transcript was hidden before the agent completed.',
+            false,
+          )
+          await this.closeWorkflowAggregateLifecycle(
+            pending,
+            hiddenState,
+            'Workflow transcript was hidden.',
+            false,
+          )
+        }
+        await this.finishDeferredResult(pending)
         return
-      pending.activeSubagents.add(toolUseId)
-      const workflowName = String(message.workflow_name ?? '').trim()
-      const description = String(message.description ?? '').trim()
-      const prompt = String(message.prompt ?? '').trim() || description || workflowName
-      await pending.handlers.onEvent({
-        type: 'tool_use',
-        toolUseId,
-        toolName: 'Agent',
-        input: {
-          description: workflowName ? `Workflow: ${workflowName}` : 'Workflow',
-          prompt,
-          subagent_type: 'workflow',
-        },
-      })
+      }
+      const toolUseId = workflowTaskToolUseId(taskId)
+      if (pending.completedWorkflowTasks.has(toolUseId)) return
+      const state = this.ensureWorkflowTask(pending, taskId)
+      if (sourceToolUseId && !state.toolUseId) state.toolUseId = sourceToolUseId
+      state.workflowName = String(message.workflow_name ?? '').trim() || state.workflowName
+      state.description = String(message.description ?? '').trim() || state.description
+      state.prompt =
+        String(message.prompt ?? '').trim() ||
+        state.prompt ||
+        state.description ||
+        state.workflowName
+      this.attachDeferredWorkflowJournal(pending, state, sourceToolUseId)
       return
     }
     if (subtype === 'task_notification') {
       const taskId = String(message.task_id ?? '')
       if (!taskId) return
+      if (pending.skippedWorkflowTaskIds?.has(taskId)) {
+        this.discardDeferredWorkflowLaunches(pending, taskId, '')
+        const hiddenState = pending.workflowTasks?.get(taskId)
+        if (hiddenState) {
+          hiddenState.terminal = true
+          await hiddenState.monitor?.stop()
+          await this.closeWorkflowAgentLifecycles(
+            pending,
+            hiddenState,
+            'Workflow transcript was hidden before the agent completed.',
+            false,
+          )
+          await this.closeWorkflowAggregateLifecycle(
+            pending,
+            hiddenState,
+            'Workflow transcript was hidden.',
+            false,
+          )
+        }
+        await this.finishDeferredResult(pending)
+        return
+      }
+      const state = pending.workflowTasks?.get(taskId)
+      if (!state) return
+      if (message.skip_transcript === true) {
+        const skipped =
+          pending.skippedWorkflowTaskIds ?? (pending.skippedWorkflowTaskIds = new Set())
+        skipped.add(taskId)
+        this.discardDeferredWorkflowLaunches(pending, taskId, state.toolUseId)
+        state.terminal = true
+        await state.monitor?.stop()
+        await this.closeWorkflowAgentLifecycles(
+          pending,
+          state,
+          'Workflow transcript was hidden before the agent completed.',
+          false,
+        )
+        await this.closeWorkflowAggregateLifecycle(
+          pending,
+          state,
+          'Workflow transcript was hidden.',
+          false,
+        )
+        await this.finishDeferredResult(pending)
+        return
+      }
       const toolUseId = workflowTaskToolUseId(taskId)
-      if (!pending.activeSubagents.delete(toolUseId)) return
-      pending.completedWorkflowTasks.add(toolUseId)
+      if (pending.completedWorkflowTasks.has(toolUseId)) {
+        state.terminal = true
+        await this.finishDeferredResult(pending)
+        return
+      }
       const status = String(message.status ?? '')
       const summary = String(message.summary ?? '').trim() || `Workflow ${status || 'finished'}`
       const usage = workflowTaskUsage(message.usage)
       const trailer = usage
         ? `\n<usage>total_tokens: ${usage.totalTokens}\ntool_uses: ${usage.toolUses}\nduration_ms: ${usage.durationMs}</usage>`
         : ''
+      if (state.monitor && !state.aggregateStarted) {
+        await settlesWithin(state.monitor.flush(), WORKFLOW_TERMINAL_FLUSH_TIMEOUT_MS)
+        await state.monitor.drain(WORKFLOW_JOURNAL_SETTLE_TIMEOUT_MS)
+        const projectedBeforeStop = this.workflowProjectedAgentIds(pending, state)
+        if (state.monitor.startedCount > 0 || projectedBeforeStop.length > 0) {
+          state.terminal = true
+        }
+        await state.monitor.stop()
+        const projectedAgentIds = this.workflowProjectedAgentIds(pending, state)
+        if (state.monitor.startedCount > 0 || projectedAgentIds.length > 0) {
+          state.terminal = true
+          await this.closeWorkflowAgentLifecycles(
+            pending,
+            state,
+            status === 'completed'
+              ? `Workflow completed before the individual transcript result became visible.\n${summary}`
+              : `Workflow ended before the agent published an individual result.\n${summary}`,
+            status !== 'completed',
+          )
+          pending.completedWorkflowTasks.add(toolUseId)
+          await pending.handlers.onEvent({
+            type: 'notice',
+            level: status === 'completed' ? 'info' : 'warning',
+            message: `${state.workflowName || `Workflow ${taskId}`}: ${summary}${trailer}`,
+          })
+          await this.finishDeferredResult(pending)
+          return
+        }
+      }
+
+      await this.ensureWorkflowAggregateStarted(pending, state)
+      if (!pending.activeSubagents.delete(toolUseId)) return
+      pending.completedWorkflowTasks.add(toolUseId)
+      state.terminal = true
       await pending.handlers.onEvent({
         type: 'tool_result',
         toolUseId,
         content: `${summary}${trailer}`,
         isError: status !== 'completed',
       })
+      await this.finishDeferredResult(pending)
     }
   }
 
@@ -577,6 +727,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
           continue
         }
         await pending.handlers.onEvent({ type: 'tool_use', toolUseId: id, toolName: name, input })
+        if (isWorkflowTool(name)) pending.workflowToolUseIds.add(id)
       }
     }
   }
@@ -585,13 +736,18 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
     // The SDK delivers tool_result blocks as a 'user' message turn from the
     // CLI's perspective. Surface them so the server can update the matching
     // tool item.
+    const workflowLaunchResult =
+      message.tool_use_result ?? (message as Record<string, unknown>).toolUseResult
+    let workflowLaunchAttached = false
     const inner = message.message as Record<string, unknown> | undefined
     if (!inner) return
     const content = (inner.content as Array<Record<string, unknown>>) || []
+    const toolResultCount = content.filter((block) => String(block.type) === 'tool_result').length
     for (const block of content) {
       if (String(block.type) !== 'tool_result') continue
       const toolUseId = String(block.tool_use_id ?? '')
       if (!toolUseId) continue
+      const isWorkflowLaunch = pending.workflowToolUseIds?.delete(toolUseId) === true
       const wasSubagent = pending.activeSubagents.delete(toolUseId)
       // Even if this was a subagent we still emit its tool_result so the
       // server's subagent state machine closes the collabAgentToolCall.
@@ -603,7 +759,287 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         content: bodyContent,
         isError,
       })
+      if (!workflowLaunchAttached && isWorkflowLaunch && toolResultCount === 1) {
+        workflowLaunchAttached = true
+        this.attachWorkflowJournal(pending, workflowLaunchResult, toolUseId)
+      }
       void wasSubagent
+    }
+  }
+
+  private attachWorkflowJournal(pending: PendingTurn, value: unknown, toolUseId: string): void {
+    const launch = parseWorkflowLaunchInfo(
+      value,
+      pending.workflowTranscriptRoots ?? defaultWorkflowTranscriptRoots(process.env),
+    )
+    if (!launch) return
+    if (pending.skippedWorkflowTaskIds?.has(launch.taskId)) return
+    const state = pending.workflowTasks?.get(launch.taskId)
+    if (!state) {
+      const boundState = [...(pending.workflowTasks?.values() ?? [])].find(
+        (candidate) => candidate.toolUseId === toolUseId,
+      )
+      if (boundState) return
+      const launches = pending.workflowLaunches ?? (pending.workflowLaunches = new Map())
+      launches.set(toolUseId, launch)
+      return
+    }
+    this.attachParsedWorkflowJournal(pending, state, launch, toolUseId)
+  }
+
+  private attachParsedWorkflowJournal(
+    pending: PendingTurn,
+    state: WorkflowTaskState,
+    launch: WorkflowLaunchInfo,
+    toolUseId: string,
+  ): void {
+    if (launch.taskId !== state.taskId) return
+    if (state.toolUseId && state.toolUseId !== toolUseId) return
+    if (!state.toolUseId) state.toolUseId = toolUseId
+    state.workflowName = launch.workflowName || state.workflowName
+    state.description = launch.summary || state.description
+    state.prompt = state.prompt || state.description || state.workflowName
+    if (state.terminal || state.aggregateStarted || state.monitor) return
+
+    state.monitor = this.createWorkflowMonitor(pending, state, launch)
+    state.monitor.start()
+  }
+
+  private attachDeferredWorkflowJournal(
+    pending: PendingTurn,
+    state: WorkflowTaskState,
+    sourceToolUseId: string,
+  ): void {
+    const launches = pending.workflowLaunches
+    if (!launches || launches.size === 0) return
+    if (sourceToolUseId) {
+      const launch = launches.get(sourceToolUseId)
+      if (!launch) return
+      launches.delete(sourceToolUseId)
+      this.attachParsedWorkflowJournal(pending, state, launch, sourceToolUseId)
+      return
+    }
+    const matches = [...launches.entries()].filter(([, launch]) => launch.taskId === state.taskId)
+    if (matches.length !== 1) return
+    const match = matches[0]
+    if (!match) return
+    const [toolUseId, launch] = match
+    launches.delete(toolUseId)
+    this.attachParsedWorkflowJournal(pending, state, launch, toolUseId)
+  }
+
+  private discardDeferredWorkflowLaunches(
+    pending: PendingTurn,
+    taskId: string,
+    sourceToolUseId: string,
+  ): void {
+    const launches = pending.workflowLaunches
+    if (!launches) return
+    if (sourceToolUseId) launches.delete(sourceToolUseId)
+    for (const [toolUseId, launch] of launches) {
+      if (launch.taskId === taskId) launches.delete(toolUseId)
+    }
+  }
+
+  private createWorkflowMonitor(
+    pending: PendingTurn,
+    state: WorkflowTaskState,
+    launch: WorkflowLaunchInfo,
+  ): WorkflowJournalMonitor {
+    return new WorkflowJournalMonitor({
+      launch,
+      onStarted: async (agent) => {
+        if (state.terminal) return
+        const toolUseId = workflowAgentToolUseId(state.taskId, agent.agentId)
+        if (
+          pending.activeSubagents.has(toolUseId) ||
+          pending.completedWorkflowTasks.has(toolUseId)
+        ) {
+          return
+        }
+        pending.activeSubagents.add(toolUseId)
+        try {
+          await pending.handlers.onEvent({
+            type: 'tool_use',
+            toolUseId,
+            toolName: 'Agent',
+            input: {
+              description: agent.description,
+              prompt: agent.prompt,
+              subagent_type: 'workflow',
+            },
+          })
+        } catch (error) {
+          pending.activeSubagents.delete(toolUseId)
+          throw error
+        }
+      },
+      onResult: async (agent) => {
+        if (state.terminal) return
+        const toolUseId = workflowAgentToolUseId(state.taskId, agent.agentId)
+        if (!pending.activeSubagents.has(toolUseId)) return
+        await pending.handlers.onEvent({
+          type: 'tool_result',
+          toolUseId,
+          content: agent.content,
+          isError: agent.isError,
+        })
+        pending.activeSubagents.delete(toolUseId)
+        pending.completedWorkflowTasks.add(toolUseId)
+      },
+    })
+  }
+
+  private workflowProjectedAgentIds(pending: PendingTurn, state: WorkflowTaskState): string[] {
+    const agentIds = new Set(state.monitor?.activeAgentIds() ?? [])
+    const prefix = `workflow-agent:${state.taskId}:`
+    for (const toolUseId of pending.activeSubagents) {
+      if (!toolUseId.startsWith(prefix)) continue
+      const agentId = toolUseId.slice(prefix.length)
+      if (agentId) agentIds.add(agentId)
+    }
+    return [...agentIds]
+  }
+
+  private async closeWorkflowAgentLifecycles(
+    pending: PendingTurn,
+    state: WorkflowTaskState,
+    message: string,
+    isError: boolean,
+  ): Promise<number> {
+    let closed = 0
+    for (const agentId of this.workflowProjectedAgentIds(pending, state)) {
+      const toolUseId = workflowAgentToolUseId(state.taskId, agentId)
+      if (!pending.activeSubagents.delete(toolUseId)) continue
+      pending.completedWorkflowTasks.add(toolUseId)
+      await pending.handlers.onEvent({
+        type: 'tool_result',
+        toolUseId,
+        content: `${message}\nagentId: ${agentId}`,
+        isError,
+      })
+      closed += 1
+    }
+    return closed
+  }
+
+  private async closeWorkflowAggregateLifecycle(
+    pending: PendingTurn,
+    state: WorkflowTaskState,
+    message: string,
+    isError: boolean,
+  ): Promise<boolean> {
+    const toolUseId = workflowTaskToolUseId(state.taskId)
+    if (!pending.activeSubagents.delete(toolUseId)) return false
+    pending.completedWorkflowTasks.add(toolUseId)
+    await pending.handlers.onEvent({
+      type: 'tool_result',
+      toolUseId,
+      content: message,
+      isError,
+    })
+    return true
+  }
+
+  private ensureWorkflowTask(pending: PendingTurn, taskId: string): WorkflowTaskState {
+    const tasks = pending.workflowTasks ?? (pending.workflowTasks = new Map())
+    const existing = tasks.get(taskId)
+    if (existing) return existing
+    const state: WorkflowTaskState = {
+      taskId,
+      toolUseId: '',
+      workflowName: '',
+      description: '',
+      prompt: '',
+      monitor: null,
+      aggregateStarted: false,
+      terminal: false,
+    }
+    tasks.set(taskId, state)
+    return state
+  }
+
+  private async ensureWorkflowAggregateStarted(
+    pending: PendingTurn,
+    state: WorkflowTaskState,
+  ): Promise<void> {
+    if (state.terminal || state.aggregateStarted) return
+    const toolUseId = workflowTaskToolUseId(state.taskId)
+    if (pending.completedWorkflowTasks.has(toolUseId)) return
+    state.aggregateStarted = true
+    pending.activeSubagents.add(toolUseId)
+    try {
+      await pending.handlers.onEvent({
+        type: 'tool_use',
+        toolUseId,
+        toolName: 'Agent',
+        input: {
+          description: state.workflowName ? `Workflow: ${state.workflowName}` : 'Workflow',
+          prompt: state.prompt || state.description || state.workflowName || 'Workflow',
+          subagent_type: 'workflow',
+        },
+      })
+    } catch (error) {
+      state.aggregateStarted = false
+      pending.activeSubagents.delete(toolUseId)
+      throw error
+    }
+  }
+
+  private async stopWorkflowTasks(pending: PendingTurn): Promise<void> {
+    const tasks = pending.workflowTasks
+    if (tasks) {
+      for (const state of tasks.values()) {
+        state.terminal = true
+        await state.monitor?.stop()
+        await this.closeWorkflowAgentLifecycles(
+          pending,
+          state,
+          'Workflow monitoring stopped before the agent published an individual result.',
+          true,
+        )
+        await this.closeWorkflowAggregateLifecycle(
+          pending,
+          state,
+          'Workflow monitoring stopped before the workflow published a terminal result.',
+          true,
+        )
+      }
+    }
+    pending.workflowLaunches?.clear()
+  }
+
+  private hasPendingWorkflowTasks(pending: PendingTurn): boolean {
+    if ((pending.workflowToolUseIds?.size ?? 0) > 0) return true
+    if ((pending.workflowLaunches?.size ?? 0) > 0) return true
+    for (const state of pending.workflowTasks?.values() ?? []) {
+      if (!state.terminal) return true
+    }
+    return false
+  }
+
+  private async finishDeferredResult(pending: PendingTurn): Promise<void> {
+    const deferred = pending.deferredResult
+    if (!deferred || pending.resolved) return
+    if (deferred.success && this.hasPendingWorkflowTasks(pending)) return
+
+    pending.deferredResult = null
+    pending.resolved = true
+    this.turns.delete(pending.context.turnId)
+    try {
+      await pending.handlers.onEvent({
+        type: 'completed',
+        success: deferred.success,
+        result: deferred.resultText,
+        claudeSessionId: deferred.claudeSessionId,
+      })
+      if (deferred.success) {
+        pending.resolve()
+      } else {
+        pending.reject(new Error(deferred.resultText ?? 'Claude turn failed'))
+      }
+    } catch (err) {
+      pending.reject(err instanceof Error ? err : new Error(String(err)))
     }
   }
 
@@ -611,6 +1047,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
     pending: PendingTurn,
     message: Record<string, unknown>,
   ): Promise<void> {
+    if (pending.deferredResult || pending.resolved) return
     const subtype = String(message.subtype ?? '')
     const success = subtype === 'success' && !message.is_error
     const resultText = message.result == null ? null : String(message.result)
@@ -632,23 +1069,9 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
     if (pending.context.outputFormat && pending.structuredBuffer) {
       await pending.handlers.onEvent({ type: 'text_delta', delta: pending.structuredBuffer.trim() })
     }
-    pending.resolved = true
-    this.turns.delete(pending.context.turnId)
-    try {
-      await pending.handlers.onEvent({
-        type: 'completed',
-        success,
-        result: resultText,
-        claudeSessionId,
-      })
-      if (success) {
-        pending.resolve()
-      } else {
-        pending.reject(new Error(resultText ?? 'Claude turn failed'))
-      }
-    } catch (err) {
-      pending.reject(err instanceof Error ? err : new Error(String(err)))
-    }
+    pending.deferredResult = { success, resultText, claudeSessionId }
+    if (!success) await this.stopWorkflowTasks(pending)
+    await this.finishDeferredResult(pending)
   }
 
   private async handleOther(
@@ -725,13 +1148,35 @@ function isSubagentTool(name: string): boolean {
   )
 }
 
+function isWorkflowTool(name: string): boolean {
+  return name === 'Workflow'
+}
+
 function isWorkflowBackgroundTask(message: Record<string, unknown>): boolean {
-  const taskType = String(message.task_type ?? '')
-  return taskType === 'local_workflow' || taskType === 'workflow'
+  return String(message.task_type ?? '') === 'local_workflow'
 }
 
 function workflowTaskToolUseId(taskId: string): string {
   return `workflow-task:${taskId}`
+}
+
+function workflowAgentToolUseId(taskId: string, agentId: string): string {
+  return `workflow-agent:${taskId}:${agentId}`
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  if (timeoutMs <= 0) return false
+  let timer: NodeJS.Timeout | null = null
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<boolean>((resolveTimeout) => {
+        timer = setTimeout(() => resolveTimeout(false), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
 }
 
 function workflowTaskUsage(value: unknown): {

--- a/src/native-runtime.mts
+++ b/src/native-runtime.mts
@@ -93,6 +93,7 @@ interface WorkflowTaskState {
   monitor: WorkflowJournalMonitor | null
   aggregateStarted: boolean
   terminal: boolean
+  monitorFailed?: boolean
 }
 
 interface PendingPermission {
@@ -138,7 +139,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         completedWorkflowTasks: new Set(),
         workflowToolUseIds: new Set(),
         workflowLaunches: new Map(),
-        workflowTranscriptRoots: defaultWorkflowTranscriptRoots(process.env),
+        workflowTranscriptRoots: defaultWorkflowTranscriptRoots(process.env, context.cwd),
         skippedWorkflowTaskIds: new Set(),
         workflowTasks: new Map(),
         toolStartSeen: new Set(),
@@ -408,7 +409,13 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         if (pending.resolved) break
       }
       if (!pending.resolved && pending.deferredResult) {
-        await this.finishDeferredResult(pending)
+        // The SDK iterator is the authoritative lifetime of a turn. If it
+        // closes while a workflow journal still has an unresolved task, there
+        // will be no later task_notification to unblock the deferred result.
+        // Close those projected agents as failed and finish the parent turn
+        // rather than leaving Codex cc's spinner alive forever.
+        if (this.hasPendingWorkflowTasks(pending)) await this.stopWorkflowTasks(pending)
+        await this.finishDeferredResult(pending, true)
         if (!pending.resolved) return
       }
       // The async iterator finished without a 'result' message — treat as
@@ -536,6 +543,10 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
     if (subtype === 'task_notification') {
       const taskId = String(message.task_id ?? '')
       if (!taskId) return
+      const knownState = pending.workflowTasks?.get(taskId)
+      const hasWorkflowHint =
+        isWorkflowBackgroundTask(message) || String(message.workflow_name ?? '').trim().length > 0
+      if (!knownState && !hasWorkflowHint) return
       if (pending.skippedWorkflowTaskIds?.has(taskId)) {
         this.discardDeferredWorkflowLaunches(pending, taskId, '')
         const hiddenState = pending.workflowTasks?.get(taskId)
@@ -558,8 +569,24 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         await this.finishDeferredResult(pending)
         return
       }
-      const state = pending.workflowTasks?.get(taskId)
-      if (!state) return
+      let state = knownState
+      if (!state) {
+        // Claude can emit task_notification before task_started (especially
+        // after a reconnect or when the SDK batches system events). Create the
+        // projected state from the notification instead of dropping the only
+        // terminal signal and leaving the parent deferred forever.
+        state = this.ensureWorkflowTask(pending, taskId)
+        const sourceToolUseId = String(message.tool_use_id ?? '')
+        if (sourceToolUseId && !state.toolUseId) state.toolUseId = sourceToolUseId
+        state.workflowName = String(message.workflow_name ?? '').trim() || state.workflowName
+        state.description = String(message.description ?? '').trim() || state.description
+        state.prompt =
+          String(message.prompt ?? '').trim() ||
+          state.prompt ||
+          state.description ||
+          state.workflowName
+        this.attachDeferredWorkflowJournal(pending, state, sourceToolUseId)
+      }
       if (message.skip_transcript === true) {
         const skipped =
           pending.skippedWorkflowTaskIds ?? (pending.skippedWorkflowTaskIds = new Set())
@@ -887,6 +914,29 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         pending.activeSubagents.delete(toolUseId)
         pending.completedWorkflowTasks.add(toolUseId)
       },
+      onError: async (error) => {
+        if (state.terminal) return
+        // Keep the task eligible for the aggregate fallback until Claude sends
+        // its terminal task_notification. This is important for security
+        // failures (for example a symlinked journal): the monitor is dead, but
+        // the task result can still close the visible Agent cleanly.
+        state.monitorFailed = true
+        state.monitor = null
+        const message = `Workflow monitoring failed: ${error.message}`
+        await this.closeWorkflowAgentLifecycles(pending, state, message, true)
+        await this.closeWorkflowAggregateLifecycle(pending, state, message, true)
+        if (state.toolUseId) pending.workflowToolUseIds.delete(state.toolUseId)
+        await pending.handlers.onEvent({
+          type: 'notice',
+          level: 'warning',
+          message,
+        })
+        if (pending.deferredResult) {
+          state.terminal = true
+          pending.completedWorkflowTasks.add(workflowTaskToolUseId(state.taskId))
+          await this.finishDeferredResult(pending, true)
+        }
+      },
     })
   }
 
@@ -1018,10 +1068,10 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
     return false
   }
 
-  private async finishDeferredResult(pending: PendingTurn): Promise<void> {
+  private async finishDeferredResult(pending: PendingTurn, force = false): Promise<void> {
     const deferred = pending.deferredResult
     if (!deferred || pending.resolved) return
-    if (deferred.success && this.hasPendingWorkflowTasks(pending)) return
+    if (!force && deferred.success && this.hasPendingWorkflowTasks(pending)) return
 
     pending.deferredResult = null
     pending.resolved = true

--- a/src/native-runtime.mts
+++ b/src/native-runtime.mts
@@ -634,6 +634,7 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
         ? `\n<usage>total_tokens: ${usage.totalTokens}\ntool_uses: ${usage.toolUses}\nduration_ms: ${usage.durationMs}</usage>`
         : ''
       const monitor = state.monitor
+      let monitorStopped = false
       if (monitor && !state.aggregateStarted && !state.monitorFailed) {
         await settlesWithin(monitor.flush(), WORKFLOW_TERMINAL_FLUSH_TIMEOUT_MS)
         // onError can replace state.monitor while flush() is awaiting I/O.
@@ -648,7 +649,12 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
             state.terminal = true
           }
           await monitor.stop()
+          monitorStopped = true
           const projectedAgentIds = this.workflowProjectedAgentIds(pending, state)
+          // A terminal notification owns this monitor even when the journal
+          // yielded no agents. Clear the state before the aggregate fallback
+          // so a late read or poll cannot keep the parent looking active.
+          if (state.monitor === monitor) state.monitor = null
           if (monitor.startedCount > 0 || projectedAgentIds.length > 0) {
             state.terminal = true
             await this.closeWorkflowAgentLifecycles(
@@ -669,6 +675,12 @@ export class NativeClaudeRuntime implements ClaudeRuntime {
             return
           }
         }
+      }
+      // If monitor failure raced with flush/drain, the error path has already
+      // detached the monitor. Stop the snapshot defensively as well; stop is
+      // idempotent and this closes the only remaining polling handle.
+      if (monitor && !monitorStopped && (state.monitor !== monitor || state.monitorFailed)) {
+        await monitor.stop()
       }
 
       await this.ensureWorkflowAggregateStarted(pending, state)

--- a/src/server-helpers.mts
+++ b/src/server-helpers.mts
@@ -355,6 +355,56 @@ export function normalizeSandboxMode(value: unknown): string | null {
   return v === 'read-only' || v === 'workspace-write' || v === 'danger-full-access' ? v : null
 }
 
+export interface PermissionProfilePolicy {
+  id: string
+  approvalPolicy: string | null
+  sandboxMode: string | null
+}
+
+export function normalizePermissionProfileId(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const id = value.trim()
+  return id.length > 0 && id.length <= 128 ? id : null
+}
+
+export function permissionProfileIdFromParams(params: Record<string, unknown>): string | null {
+  const direct = normalizePermissionProfileId(params.permissions)
+  if (direct) return direct
+  const active = asRecord(params.activePermissionProfile)
+  return normalizePermissionProfileId(active.id)
+}
+
+export function permissionProfilePolicy(value: unknown): PermissionProfilePolicy | null {
+  const id = normalizePermissionProfileId(value)
+  if (!id) return null
+  switch (id) {
+    case ':read-only':
+      return { id, approvalPolicy: 'on-request', sandboxMode: 'read-only' }
+    case ':workspace':
+      return { id, approvalPolicy: 'on-request', sandboxMode: 'workspace-write' }
+    case ':danger-full-access':
+      return { id, approvalPolicy: 'never', sandboxMode: 'danger-full-access' }
+    default:
+      // Custom profiles are still reported to the App, but their policy is
+      // resolved by the caller's explicit approval/sandbox fields when those
+      // are available. Never silently grant a broader policy for an unknown id.
+      return { id, approvalPolicy: null, sandboxMode: null }
+  }
+}
+
+export function threadPermissionProfileId(
+  permissionProfileId: string | null | undefined,
+  approvalPolicy: string | null,
+  sandboxMode: string | null,
+): string | null {
+  const explicit = normalizePermissionProfileId(permissionProfileId)
+  if (explicit) return explicit
+  if (sandboxMode === 'read-only') return ':read-only'
+  if (sandboxMode === 'danger-full-access') return ':danger-full-access'
+  if (sandboxMode === 'workspace-write' && approvalPolicy === 'on-request') return ':workspace'
+  return null
+}
+
 // turn/start uses `sandboxPolicy: SandboxPolicy` (a struct) instead of the
 // thread/start `sandbox: SandboxMode` string. Translate the struct's `type`
 // back to the internal canonical mode string the sidecar understands.
@@ -495,7 +545,7 @@ export function personalityPromptCue(personality: string | null): string | null 
 // chosen tier. Returning the right shape lets the App render the correct badge
 // (Read-only / Workspace / Full access) and stops it from over-prompting.
 export function sandboxEnvelope(mode: string | null, cwd: string): unknown {
-  if (mode === 'read-only') return { type: 'readOnly' }
+  if (mode === 'read-only') return { type: 'readOnly', networkAccess: false }
   if (mode === 'danger-full-access') return { type: 'dangerFullAccess' }
   // Default: workspace-write (or null/legacy).
   return {

--- a/src/server-helpers.mts
+++ b/src/server-helpers.mts
@@ -507,6 +507,27 @@ export function sandboxEnvelope(mode: string | null, cwd: string): unknown {
   }
 }
 
+export function permissionProfileList(params: Record<string, unknown>): unknown {
+  const profiles = [
+    { id: ':read-only', description: null, allowed: true },
+    { id: ':workspace', description: null, allowed: true },
+    { id: ':danger-full-access', description: null, allowed: true },
+  ]
+  const rawCursor = params.cursor
+  const start = rawCursor == null ? 0 : Number(rawCursor)
+  if (!Number.isInteger(start) || start < 0 || start > profiles.length) {
+    throw new Error('invalid permission profile cursor')
+  }
+  const rawLimit = params.limit
+  const requestedLimit = typeof rawLimit === 'number' && Number.isFinite(rawLimit) ? rawLimit : null
+  const limit = requestedLimit == null ? profiles.length : Math.max(1, Math.floor(requestedLimit))
+  const end = Math.min(profiles.length, start + limit)
+  return {
+    data: profiles.slice(start, end),
+    nextCursor: end < profiles.length ? String(end) : null,
+  }
+}
+
 export function emptyTokenBreakdown(): TokenUsageBreakdown {
   return {
     totalTokens: 0,

--- a/src/server-helpers.mts
+++ b/src/server-helpers.mts
@@ -374,6 +374,16 @@ export function permissionProfileIdFromParams(params: Record<string, unknown>): 
   return normalizePermissionProfileId(active.id)
 }
 
+export function hasLegacyPermissionParams(params: Record<string, unknown>): boolean {
+  return (
+    typeof params.approvalPolicy === 'string' ||
+    typeof params.sandbox === 'string' ||
+    (params.sandboxPolicy !== null &&
+      typeof params.sandboxPolicy === 'object' &&
+      !Array.isArray(params.sandboxPolicy))
+  )
+}
+
 export function permissionProfilePolicy(value: unknown): PermissionProfilePolicy | null {
   const id = normalizePermissionProfileId(value)
   if (!id) return null

--- a/src/server.mts
+++ b/src/server.mts
@@ -51,7 +51,9 @@ import {
   parseExitCodeFromResult,
   parseSubagentTrailer,
   parseWebSearchAction,
+  permissionProfileIdFromParams,
   permissionProfileList,
+  permissionProfilePolicy,
   personalityPromptCue,
   readConfigReasoningEffort,
   reasoningEffortFromParams,
@@ -64,6 +66,7 @@ import {
   stringOr,
   summarizeInjectedItem,
   summarizeRpcParams,
+  threadPermissionProfileId,
   todoWriteToPlanSteps,
   tokenBreakdownFromClaudeUsage,
   toolResultText,
@@ -119,6 +122,21 @@ import { parseWorkflowCommand } from './workflow-command.mjs'
 import { maybeCreateThreadWorktree } from './worktree.mjs'
 
 const execFileAsync = promisify(execFile)
+
+// A missing Claude Task result must not keep Codex cc in its working state
+// forever. This is deliberately a long, configurable watchdog for the whole
+// subagent phase; it is not the short journal-drain grace period used when a
+// terminal notification has already arrived.
+const DEFAULT_SUBAGENT_WATCHDOG_MS = 30 * 60 * 1000
+const MIN_SUBAGENT_WATCHDOG_MS = 100
+
+function subagentWatchdogTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.CLAUDE_CODEX_SUBAGENT_TIMEOUT_MS?.trim()
+  if (!raw) return DEFAULT_SUBAGENT_WATCHDOG_MS
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0
+  return Math.max(MIN_SUBAGENT_WATCHDOG_MS, Math.floor(parsed))
+}
 
 type TurnItemsView = 'full' | 'summary' | 'notLoaded'
 
@@ -339,6 +357,8 @@ export class CodexClaudeAppServer {
         return this.threadGoalClear(asRecord(params))
       case 'thread/metadata/update':
         return this.threadMetadataUpdate(asRecord(params))
+      case 'thread/settings/update':
+        return this.threadSettingsUpdate(peer, asRecord(params))
       // Intentional no-ops: Claude Code has no equivalent concept, so the
       // adapter acknowledges the call without side effects rather than failing
       // the RPC (which would break the Codex App connection).
@@ -572,6 +592,8 @@ export class CodexClaudeAppServer {
     const cwd = maybeCreateThreadWorktree(id, requestedCwd).cwd
     const model = modelFromParams(params, this.configModel)
     const reasoningEffort = reasoningEffortFromParams(params, this.configReasoningEffort)
+    const permissionProfileId = permissionProfileIdFromParams(params)
+    const permissionProfile = permissionProfilePolicy(permissionProfileId)
     const selectedProviderLoop = resolveProviderLoopSelection(this.providerLoopSelectionInput())
     const thread: ThreadRecord = {
       id,
@@ -591,8 +613,10 @@ export class CodexClaudeAppServer {
       createdAt: now,
       updatedAt: now,
       status: { type: 'idle' },
-      approvalPolicy: normalizeApprovalPolicy(params.approvalPolicy),
-      sandboxMode: normalizeSandboxMode(params.sandbox),
+      approvalPolicy:
+        permissionProfile?.approvalPolicy ?? normalizeApprovalPolicy(params.approvalPolicy),
+      sandboxMode: permissionProfile?.sandboxMode ?? normalizeSandboxMode(params.sandbox),
+      permissionProfileId: permissionProfile?.id ?? null,
       ephemeral: params.ephemeral === true,
       threadSource: normalizeThreadSource(params.threadSource),
       agentRole: nullIfEmpty(typeof params.agentRole === 'string' ? params.agentRole : null),
@@ -636,6 +660,8 @@ export class CodexClaudeAppServer {
     if (typeof params.cwd === 'string' && params.cwd.length > 0) thread.cwd = params.cwd
     const model = modelFromParams(params, null)
     const reasoningEffort = reasoningEffortFromParams(params, null)
+    const permissionProfileId = permissionProfileIdFromParams(params)
+    const permissionProfile = permissionProfilePolicy(permissionProfileId)
     if (model) {
       // runtimeBackend is pinned at thread/start. Refuse cross-backend
       // model changes on resume — the conversation history wouldn't carry
@@ -655,10 +681,17 @@ export class CodexClaudeAppServer {
       }
     }
     if (reasoningEffort) thread.reasoningEffort = reasoningEffort
-    if (typeof params.approvalPolicy === 'string')
-      thread.approvalPolicy = normalizeApprovalPolicy(params.approvalPolicy)
-    if (typeof params.sandbox === 'string')
-      thread.sandboxMode = normalizeSandboxMode(params.sandbox)
+    if (permissionProfileId) {
+      thread.permissionProfileId = permissionProfileId
+      if (permissionProfile?.approvalPolicy)
+        thread.approvalPolicy = permissionProfile.approvalPolicy
+      if (permissionProfile?.sandboxMode) thread.sandboxMode = permissionProfile.sandboxMode
+    } else {
+      if (typeof params.approvalPolicy === 'string')
+        thread.approvalPolicy = normalizeApprovalPolicy(params.approvalPolicy)
+      if (typeof params.sandbox === 'string')
+        thread.sandboxMode = normalizeSandboxMode(params.sandbox)
+    }
     if (typeof params.threadSource === 'string')
       thread.threadSource = normalizeThreadSource(params.threadSource)
     if (typeof params.baseInstructions === 'string')
@@ -677,6 +710,7 @@ export class CodexClaudeAppServer {
       ephemeral: thread.ephemeral,
     })
     this.activePeerByThread.set(threadId, peer)
+    this.bindPeerToDescendants(peer, threadId)
     return this.threadEnvelope(
       thread,
       params.excludeTurns === true ? [] : this.store.listTurns(thread.id),
@@ -705,13 +739,17 @@ export class CodexClaudeAppServer {
       updatedAt: now,
       status: { type: 'idle' },
       approvalPolicy:
-        typeof params.approvalPolicy === 'string'
+        permissionProfilePolicy(permissionProfileIdFromParams(params))?.approvalPolicy ??
+        (typeof params.approvalPolicy === 'string'
           ? normalizeApprovalPolicy(params.approvalPolicy)
-          : parent.approvalPolicy,
+          : parent.approvalPolicy),
       sandboxMode:
-        typeof params.sandbox === 'string'
+        permissionProfilePolicy(permissionProfileIdFromParams(params))?.sandboxMode ??
+        (typeof params.sandbox === 'string'
           ? normalizeSandboxMode(params.sandbox)
-          : parent.sandboxMode,
+          : parent.sandboxMode),
+      permissionProfileId:
+        permissionProfileIdFromParams(params) ?? parent.permissionProfileId ?? null,
       ephemeral: parent.ephemeral,
       threadSource:
         typeof params.threadSource === 'string'
@@ -1014,6 +1052,60 @@ export class CodexClaudeAppServer {
     const thread = this.store.getThread(threadId)
     if (!thread) throw new Error(`unknown thread: ${threadId}`)
     return { thread: this.toThread(thread, this.store.listTurns(threadId)) }
+  }
+
+  private threadSettingsUpdate(peer: RpcPeer, params: Record<string, unknown>): unknown {
+    const threadId = stringOr(params.threadId, '')
+    const thread = this.store.getThread(threadId)
+    if (!thread) throw new Error(`unknown thread: ${threadId}`)
+
+    const permissionProfileId = permissionProfileIdFromParams(params)
+    const permissionProfile = permissionProfilePolicy(permissionProfileId)
+    if (permissionProfileId) thread.permissionProfileId = permissionProfileId
+    if (permissionProfile?.approvalPolicy) thread.approvalPolicy = permissionProfile.approvalPolicy
+    if (permissionProfile?.sandboxMode) thread.sandboxMode = permissionProfile.sandboxMode
+    if (typeof params.approvalPolicy === 'string' && !permissionProfile)
+      thread.approvalPolicy = normalizeApprovalPolicy(params.approvalPolicy)
+    const sandboxMode = sandboxFromTurnParams(params)
+    if (sandboxMode && !permissionProfile) thread.sandboxMode = sandboxMode
+    if (typeof params.cwd === 'string' && params.cwd.length > 0) thread.cwd = params.cwd
+    this.store.upsertThread(thread)
+
+    const activePermissionProfileId = threadPermissionProfileId(
+      thread.permissionProfileId,
+      thread.approvalPolicy,
+      thread.sandboxMode,
+    )
+    this.notify(peer, {
+      method: 'thread/settings/updated',
+      params: {
+        threadId,
+        threadSettings: {
+          cwd: thread.cwd,
+          approvalPolicy: thread.approvalPolicy ?? 'on-request',
+          approvalsReviewer: 'user',
+          sandboxPolicy: sandboxEnvelope(thread.sandboxMode, thread.cwd),
+          activePermissionProfile: activePermissionProfileId
+            ? { id: activePermissionProfileId, extends: null }
+            : null,
+          model: thread.model,
+          modelProvider: thread.modelProvider,
+          serviceTier: null,
+          effort: thread.reasoningEffort,
+          summary: null,
+          collaborationMode: {
+            mode: 'default',
+            settings: {
+              model: thread.model,
+              reasoning_effort: thread.reasoningEffort,
+              developer_instructions: thread.developerInstructions,
+            },
+          },
+          personality: thread.personality,
+        },
+      },
+    })
+    return {}
   }
 
   private threadRollback(params: Record<string, unknown>): unknown {
@@ -1350,8 +1442,21 @@ export class CodexClaudeAppServer {
     if (typeof params.cwd === 'string' && params.cwd.length > 0) thread.cwd = params.cwd
     const model = modelFromParams(params, thread.model)
     const reasoningEffort = reasoningEffortFromParams(params, thread.reasoningEffort)
+    const permissionProfileId = permissionProfileIdFromParams(params)
+    const permissionProfile = permissionProfilePolicy(permissionProfileId)
     if (model) thread.model = model
     if (reasoningEffort) thread.reasoningEffort = reasoningEffort
+    if (permissionProfileId) {
+      thread.permissionProfileId = permissionProfileId
+      if (permissionProfile?.approvalPolicy)
+        thread.approvalPolicy = permissionProfile.approvalPolicy
+      if (permissionProfile?.sandboxMode) thread.sandboxMode = permissionProfile.sandboxMode
+    } else {
+      if (typeof params.approvalPolicy === 'string')
+        thread.approvalPolicy = normalizeApprovalPolicy(params.approvalPolicy)
+      const requestedSandbox = sandboxFromTurnParams(params)
+      if (requestedSandbox) thread.sandboxMode = requestedSandbox
+    }
     this.store.upsertThread(thread)
     if (!thread.preview && prompt) {
       thread.preview = prompt.slice(0, 200)
@@ -1649,11 +1754,15 @@ export class CodexClaudeAppServer {
     // the thread-level setting captured at start/resume. turn/start ships a
     // sandboxPolicy struct (e.g. {type:"dangerFullAccess"}); thread/start uses
     // the simpler sandbox string. Both are honoured.
+    const permissionProfile = permissionProfilePolicy(permissionProfileIdFromParams(params))
     const approvalPolicy =
+      permissionProfile?.approvalPolicy ??
       (typeof params.approvalPolicy === 'string'
         ? normalizeApprovalPolicy(params.approvalPolicy)
-        : null) ?? thread.approvalPolicy
-    const sandboxMode = sandboxFromTurnParams(params) ?? thread.sandboxMode
+        : null) ??
+      thread.approvalPolicy
+    const sandboxMode =
+      permissionProfile?.sandboxMode ?? sandboxFromTurnParams(params) ?? thread.sandboxMode
     // Per-turn instruction overrides: Codex App may resend its instruction
     // panel state when the user toggles personality mid-thread. Falls back to
     // whatever was captured at thread/start.
@@ -1712,6 +1821,36 @@ export class CodexClaudeAppServer {
       contexts: subagentContexts,
       active: activeSubagents,
     })
+    let acceptRuntimeEvents = true
+    let watchdogTimer: NodeJS.Timeout | null = null
+    let resolveWatchdog: (() => void) | null = null
+    const watchdogTimeoutMs = subagentWatchdogTimeoutMs()
+    const watchdogPromise =
+      watchdogTimeoutMs > 0
+        ? new Promise<void>((resolve) => {
+            resolveWatchdog = resolve
+          })
+        : null
+    const disarmWatchdog = (): void => {
+      if (watchdogTimer) clearTimeout(watchdogTimer)
+      watchdogTimer = null
+    }
+    const armWatchdog = (): void => {
+      if (!watchdogPromise || watchdogTimer || !acceptRuntimeEvents || activeSubagents.size === 0)
+        return
+      watchdogTimer = setTimeout(() => {
+        watchdogTimer = null
+        // Flip this before resolving the race so an already-buffered SDK event
+        // cannot create a fresh child after the watchdog has decided to fail.
+        acceptRuntimeEvents = false
+        resolveWatchdog?.()
+      }, watchdogTimeoutMs)
+      watchdogTimer.unref()
+    }
+    const turnIsActive = (): boolean =>
+      acceptRuntimeEvents &&
+      this.store.getTurn(turn.id)?.status === 'inProgress' &&
+      this.activeTurnByThread.get(thread.id) === turn.id
     const runtimeTurn = this.runtime.runTurn(
       {
         threadId: thread.id,
@@ -1739,6 +1878,11 @@ export class CodexClaudeAppServer {
       },
       {
         onEvent: async (event) => {
+          // Interrupts, watchdog expiry, and a peer reconnect can leave a few
+          // SDK messages queued after the server has terminalized the turn.
+          // They are stale and must never resurrect a child or an inProgress
+          // item in the Codex App.
+          if (!turnIsActive()) return
           if (event.type === 'session') {
             this.store.updateClaudeSessionId(thread.id, event.claudeSessionId)
             return
@@ -1809,6 +1953,10 @@ export class CodexClaudeAppServer {
               codexSessionId: null,
             }
             this.store.upsertThread(childThread)
+            // Child notifications must follow the current parent peer. This
+            // matters after unix-daemon reconnects, when the old peer is gone
+            // before the child publishes its response.
+            this.activePeerByThread.set(childThreadId, peer)
             const childTurn: TurnRecord = {
               id: newId(),
               threadId: childThreadId,
@@ -1946,6 +2094,7 @@ export class CodexClaudeAppServer {
             itemIds.set(event.toolUseId, waitId)
             subagentContexts.set(event.toolUseId, subagentContext)
             activeSubagents.add(event.toolUseId)
+            armWatchdog()
             return
           }
           if (event.type === 'tool_result' && activeSubagents.has(event.toolUseId)) {
@@ -2064,6 +2213,7 @@ export class CodexClaudeAppServer {
                 completedAtMs: nowMillis(),
               },
             })
+            if (activeSubagents.size === 0) disarmWatchdog()
             return
           }
           if (event.type === 'text_delta') {
@@ -2341,6 +2491,7 @@ export class CodexClaudeAppServer {
           }
         },
         onPermissionRequest: async (event) => {
+          if (!turnIsActive()) return { decision: 'cancel' }
           let itemId = itemIds.get(event.toolUseId)
           if (!itemId) {
             const item = this.toolUseToItem(
@@ -2372,6 +2523,7 @@ export class CodexClaudeAppServer {
             }
           }
           const decision = await this.requestApproval(peer, thread.id, turn.id, itemId, event)
+          if (!turnIsActive()) return { decision: 'cancel' }
           if (decision.decision === 'acceptForSession') {
             const command = String(event.input.command ?? '')
             if (command) {
@@ -2383,6 +2535,7 @@ export class CodexClaudeAppServer {
           return decision
         },
         onUserInputRequest: async (event) => {
+          if (!turnIsActive()) return { answers: {} }
           // Render AskUserQuestion as Codex's native dynamicToolCall item +
           // item/tool/requestUserInput reverse RPC. The App pops its
           // structured choice card; we wait for the answers, finalise the
@@ -2416,6 +2569,7 @@ export class CodexClaudeAppServer {
             item.id,
             event.questions,
           )
+          if (!turnIsActive()) return { answers: {} }
           const contentItems = userInputAnswersAsContent(event.questions, answers)
           const completedItem: ThreadItem = {
             ...item,
@@ -2439,21 +2593,53 @@ export class CodexClaudeAppServer {
         },
       },
     )
-    await runtimeTurn.then(
-      () => {
-        if (this.store.getTurn(turn.id)?.status === 'inProgress') {
-          this.finalizeOrphanedSubagents(peer, thread, turn, subagentContexts, activeSubagents)
-        }
-        this.subagentStateByTurn.delete(turn.id)
-      },
-      (error: unknown) => {
-        if (this.store.getTurn(turn.id)?.status === 'inProgress') {
-          this.finalizeOrphanedSubagents(peer, thread, turn, subagentContexts, activeSubagents)
-        }
-        this.subagentStateByTurn.delete(turn.id)
-        throw error
-      },
+    const runtimeOutcome = runtimeTurn.then(
+      () => ({ kind: 'resolved' as const }),
+      (error: unknown) => ({
+        kind: 'rejected' as const,
+        error: error instanceof Error ? error : new Error(String(error)),
+      }),
     )
+    const outcome = watchdogPromise
+      ? await Promise.race([
+          runtimeOutcome,
+          watchdogPromise.then(() => ({ kind: 'timeout' as const })),
+        ])
+      : await runtimeOutcome
+    disarmWatchdog()
+    acceptRuntimeEvents = false
+    if (outcome.kind === 'timeout') {
+      const timeoutSeconds = Math.ceil(watchdogTimeoutMs / 1000)
+      const timeoutUnit = timeoutSeconds === 1 ? 'second' : 'seconds'
+      const message = `Subagent did not publish a terminal result within ${timeoutSeconds} ${timeoutUnit}.`
+      if (this.store.getTurn(turn.id)?.status === 'inProgress') {
+        this.finalizeOrphanedSubagents(
+          peer,
+          thread,
+          turn,
+          subagentContexts,
+          activeSubagents,
+          message,
+        )
+        this.subagentStateByTurn.delete(turn.id)
+        // Do not await the SDK interrupt here: some SDK versions wait for the
+        // same result that has just timed out. The server catch path will
+        // terminalize the parent turn immediately and late events are guarded.
+        void this.runtime.interrupt(thread.id).catch(() => {})
+      }
+      throw new Error(message)
+    }
+    if (outcome.kind === 'rejected') {
+      if (this.store.getTurn(turn.id)?.status === 'inProgress') {
+        this.finalizeOrphanedSubagents(peer, thread, turn, subagentContexts, activeSubagents)
+      }
+      this.subagentStateByTurn.delete(turn.id)
+      throw outcome.error
+    }
+    if (this.store.getTurn(turn.id)?.status === 'inProgress') {
+      this.finalizeOrphanedSubagents(peer, thread, turn, subagentContexts, activeSubagents)
+    }
+    this.subagentStateByTurn.delete(turn.id)
     const currentTurn = this.store.getTurn(turn.id)
     if (currentTurn && currentTurn.status !== 'inProgress') return
 
@@ -2616,7 +2802,11 @@ export class CodexClaudeAppServer {
       agentThreadId: context.childThreadId,
       agentPath: context.agentPath,
     }
-    this.store.appendItem(parentTurnId, item)
+    // Codex cc 26.818 rejects `kind: completed` when replaying history. The
+    // live notification is useful to newer clients, but the terminal wait
+    // item and child turn already carry the durable completion state, so keep
+    // the persisted representation legacy-safe.
+    if (kind !== 'completed') this.store.appendItem(parentTurnId, item)
     this.emitItemLifecycle(peer, parentThreadId, parentTurnId, item)
   }
 
@@ -2659,6 +2849,7 @@ export class CodexClaudeAppServer {
     turn: TurnRecord,
     contexts: Map<string, SubagentContext>,
     active: Set<string>,
+    failureMessage = 'Subagent ended without a terminal task result.',
   ): void {
     for (const toolUseId of Array.from(active)) {
       const context = contexts.get(toolUseId)
@@ -2666,7 +2857,7 @@ export class CodexClaudeAppServer {
       contexts.delete(toolUseId)
       if (!context) continue
 
-      const message = 'Subagent ended without a terminal task result.'
+      const message = failureMessage
       const childTurn = this.completeSubagentChildTurn(peer, context, message, 'failed', {
         message,
       })
@@ -2808,7 +2999,6 @@ export class CodexClaudeAppServer {
     const requestedTurnId = stringOr(params.turnId, '')
     this.activePeerByThread.set(threadId, peer)
     const activeTurnId = this.activeTurnByThread.get(threadId)
-    const interrupting = this.runtime.interrupt(threadId)
     const turnId = activeTurnId || requestedTurnId
     if (turnId) {
       const turn = this.store.getTurn(turnId)
@@ -2834,6 +3024,11 @@ export class CodexClaudeAppServer {
     }
     this.clearActiveTurn(threadId)
     this.setThreadStatus(peer, threadId, { type: 'idle' })
+    // Persist the terminal state before asking the SDK to abort. A few SDK
+    // versions deliver one or two buffered tool events during interrupt; the
+    // runRuntimeTurn guard now rejects them because the turn is no longer
+    // active, so they cannot create an orphan child after this point.
+    const interrupting = this.runtime.interrupt(threadId)
     await interrupting
     return {}
   }
@@ -3708,6 +3903,11 @@ export class CodexClaudeAppServer {
   }
 
   private threadEnvelope(thread: ThreadRecord, turns: TurnRecord[] = []): unknown {
+    const activePermissionProfileId = threadPermissionProfileId(
+      thread.permissionProfileId,
+      thread.approvalPolicy,
+      thread.sandboxMode,
+    )
     return {
       thread: this.toThread(thread, turns),
       model: thread.model,
@@ -3719,7 +3919,13 @@ export class CodexClaudeAppServer {
       approvalsReviewer: 'user',
       sandbox: sandboxEnvelope(thread.sandboxMode, thread.cwd),
       permissionProfile: null,
-      activePermissionProfile: null,
+      activePermissionProfile: activePermissionProfileId
+        ? { id: activePermissionProfileId, extends: null }
+        : null,
+      // Some newer clients read the compact id while older clients use the
+      // structured activePermissionProfile field. Return both; unknown extra
+      // fields are ignored by the legacy app-server schema.
+      permissions: activePermissionProfileId,
       reasoningEffort: thread.reasoningEffort,
     }
   }
@@ -3947,7 +4153,39 @@ export class CodexClaudeAppServer {
   private peerForParams(peer: RpcPeer, params: unknown): RpcPeer {
     const threadId = stringOr(asRecord(params).threadId, '')
     if (!threadId) return peer
-    return this.activePeerByThread.get(threadId) ?? peer
+    const direct = this.activePeerByThread.get(threadId)
+    if (direct) return direct
+    const seen = new Set<string>()
+    let current = this.store.getThread(threadId)
+    while (current?.forkedFromId && !seen.has(current.forkedFromId)) {
+      seen.add(current.forkedFromId)
+      const ancestorPeer = this.activePeerByThread.get(current.forkedFromId)
+      if (ancestorPeer) {
+        this.activePeerByThread.set(threadId, ancestorPeer)
+        return ancestorPeer
+      }
+      current = this.store.getThread(current.forkedFromId)
+    }
+    return peer
+  }
+
+  private bindPeerToDescendants(peer: RpcPeer, rootThreadId: string): void {
+    const queue = [rootThreadId]
+    const seen = new Set<string>()
+    while (queue.length > 0) {
+      const parentId = queue.shift()
+      if (!parentId || seen.has(parentId)) continue
+      seen.add(parentId)
+      for (const child of this.store.listThreads({
+        includeEphemeral: true,
+        parentThreadId: parentId,
+        sortKey: 'created_at',
+        sortDirection: 'asc',
+      })) {
+        this.activePeerByThread.set(child.id, peer)
+        queue.push(child.id)
+      }
+    }
   }
 
   private loadPersistedConfig(): void {

--- a/src/server.mts
+++ b/src/server.mts
@@ -741,6 +741,19 @@ export class CodexClaudeAppServer {
   }
 
   private threadList(params: Record<string, unknown>): unknown {
+    const sourceKinds = Array.isArray(params.sourceKinds)
+      ? params.sourceKinds.filter((value): value is string => typeof value === 'string')
+      : []
+    const parentThreadId =
+      typeof params.parentThreadId === 'string' && params.parentThreadId.length > 0
+        ? params.parentThreadId
+        : null
+    const ancestorThreadId =
+      typeof params.ancestorThreadId === 'string' && params.ancestorThreadId.length > 0
+        ? params.ancestorThreadId
+        : null
+    const sortKey = params.sortKey === 'created_at' ? 'created_at' : 'updated_at'
+    const sortDirection = params.sortDirection === 'asc' ? 'asc' : 'desc'
     const threads = this.store.listThreads({
       archived: (params.archived as boolean | null | undefined) ?? null,
       limit: numberOr(params.limit, 50),
@@ -750,13 +763,22 @@ export class CodexClaudeAppServer {
           ? (params.cwd as string | string[])
           : null,
       includeEphemeral: params.includeEphemeral === true,
+      parentThreadId,
+      ancestorThreadId,
+      sourceKinds,
+      sortKey,
+      sortDirection,
     })
     const last = threads.at(-1)
     return {
       data: threads.map((thread) => this.toThread(thread, [])),
       nextCursor:
-        last && threads.length >= numberOr(params.limit, 50) ? String(last.updatedAt) : null,
-      backwardsCursor: threads[0] ? String(threads[0].updatedAt) : null,
+        last && threads.length >= numberOr(params.limit, 50)
+          ? String(sortKey === 'created_at' ? last.createdAt : last.updatedAt)
+          : null,
+      backwardsCursor: threads[0]
+        ? String(sortKey === 'created_at' ? threads[0].createdAt : threads[0].updatedAt)
+        : null,
     }
   }
 
@@ -3808,9 +3830,7 @@ export class CodexClaudeAppServer {
   private toCompletedTurn(turn: TurnRecord): unknown {
     const lastAgent =
       turn.status === 'completed' && turn.error == null
-        ? turn.items.findLast(
-            (item) => item.type === 'agentMessage' && item.text.trim().length > 0,
-          )
+        ? turn.items.findLast((item) => item.type === 'agentMessage' && item.text.trim().length > 0)
         : undefined
     return {
       id: turn.id,

--- a/src/server.mts
+++ b/src/server.mts
@@ -867,7 +867,13 @@ export class CodexClaudeAppServer {
     const threadId = stringOr(params.threadId, '')
     const thread = this.store.getThread(threadId)
     if (!thread) throw new Error('unknown thread: ' + threadId)
-    const turns = params.includeTurns === false ? [] : this.store.listTurns(threadId)
+    // Codex cc hydrates the Subagent panel with includeTurns:false. A
+    // parent-linked child with no renderable turns is treated by that client
+    // as still loading, and it does not reliably follow up with turns/list.
+    // Keep metadata-only reads for ordinary threads, but return the small
+    // child transcript so Prompt/Response and the terminal state can render.
+    const includeTurns = params.includeTurns !== false || thread.threadSource === 'subagent'
+    const turns = includeTurns ? this.store.listTurns(threadId) : []
     return { thread: this.toThread(thread, turns) }
   }
 

--- a/src/server.mts
+++ b/src/server.mts
@@ -2250,10 +2250,11 @@ export class CodexClaudeAppServer {
             })
 
             // Codex cc 26.x does not advertise the terminal
-            // subAgentActivity kind and closes its spinner via the legacy
-            // closeAgent lifecycle. Modern peers already have the activity
-            // completion and must not receive a duplicate close.
-            if (!this.supportsCompletedSubagentActivity(peer)) {
+            // subAgentActivity kind. For a successful child, wait/completed
+            // is already the terminal display state; appending closeAgent
+            // makes the bundled client hide the finished child. Keep the
+            // legacy closeAgent cleanup only for failed results.
+            if (!this.supportsCompletedSubagentActivity(peer) && event.isError) {
               const closeId = newId()
               const closeBegin: ThreadItem = {
                 type: 'collabAgentToolCall',

--- a/src/server.mts
+++ b/src/server.mts
@@ -2242,6 +2242,51 @@ export class CodexClaudeAppServer {
                 completedAtMs: nowMillis(),
               },
             })
+
+            // Codex cc 26.x does not advertise the terminal
+            // subAgentActivity kind and closes its spinner via the legacy
+            // closeAgent lifecycle. Modern peers already have the activity
+            // completion and must not receive a duplicate close.
+            if (!this.supportsCompletedSubagentActivity(peer)) {
+              const closeId = newId()
+              const closeBegin: ThreadItem = {
+                type: 'collabAgentToolCall',
+                id: closeId,
+                tool: 'closeAgent',
+                status: 'inProgress',
+                senderThreadId: thread.id,
+                receiverThreadIds: [ctx.childThreadId],
+                prompt: null,
+                model: null,
+                reasoningEffort: null,
+                agentsStates: {},
+              }
+              this.store.appendItem(turn.id, closeBegin)
+              this.notify(peer, {
+                method: 'item/started',
+                params: {
+                  threadId: thread.id,
+                  turnId: turn.id,
+                  item: closeBegin,
+                  startedAtMs: nowMillis(),
+                },
+              })
+              const closeEnd: ThreadItem = {
+                ...closeBegin,
+                status: collabStatus,
+                agentsStates: { [ctx.childThreadId]: { status: agentStatus, message: null } },
+              }
+              this.store.updateItem(turn.id, closeId, () => closeEnd)
+              this.notify(peer, {
+                method: 'item/completed',
+                params: {
+                  threadId: thread.id,
+                  turnId: turn.id,
+                  item: closeEnd,
+                  completedAtMs: nowMillis(),
+                },
+              })
+            }
             // Keep the context discoverable until the child turn and wait
             // item have both been persisted. If one of those operations throws,
             // the outer settlement path can still finalize the child as failed.
@@ -2942,6 +2987,46 @@ export class CodexClaudeAppServer {
           completedAtMs: nowMillis(),
         },
       })
+      if (!this.supportsCompletedSubagentActivity(peer)) {
+        const closeId = newId()
+        const closeBegin: ThreadItem = {
+          type: 'collabAgentToolCall',
+          id: closeId,
+          tool: 'closeAgent',
+          status: 'inProgress',
+          senderThreadId: thread.id,
+          receiverThreadIds: [context.childThreadId],
+          prompt: null,
+          model: null,
+          reasoningEffort: null,
+          agentsStates: {},
+        }
+        this.store.appendItem(turn.id, closeBegin)
+        this.notify(peer, {
+          method: 'item/started',
+          params: {
+            threadId: thread.id,
+            turnId: turn.id,
+            item: closeBegin,
+            startedAtMs: nowMillis(),
+          },
+        })
+        const closeEnd: ThreadItem = {
+          ...closeBegin,
+          status: 'failed',
+          agentsStates: { [context.childThreadId]: { status: 'errored', message } },
+        }
+        this.store.updateItem(turn.id, closeId, () => closeEnd)
+        this.notify(peer, {
+          method: 'item/completed',
+          params: {
+            threadId: thread.id,
+            turnId: turn.id,
+            item: closeEnd,
+            completedAtMs: nowMillis(),
+          },
+        })
+      }
     }
   }
 

--- a/src/server.mts
+++ b/src/server.mts
@@ -2895,12 +2895,12 @@ export class CodexClaudeAppServer {
       agentThreadId: context.childThreadId,
       agentPath: context.agentPath,
     }
-    // The durable wait/child-turn state is enough while a modern peer is
-    // live. Persist only terminal activity for modern peers; replaying a
-    // persisted `started` marker after a same-process thread/read would make
-    // a completed child look active again. Legacy peers never receive the
-    // successful activity kinds and keep the existing interrupted marker.
-    if (kind !== 'started') this.store.appendItem(parentTurnId, item)
+    // Keep the persisted history capability-neutral. The durable wait and
+    // child-turn state covers live and completed runs; persisting either
+    // started or completed activity would make a mixed-version reconnect
+    // decode a kind the peer may not support. Interrupted remains the one
+    // legacy-safe terminal marker for abandoned children.
+    if (kind === 'interrupted') this.store.appendItem(parentTurnId, item)
     this.emitItemLifecycle(peer, parentThreadId, parentTurnId, item)
   }
 

--- a/src/server.mts
+++ b/src/server.mts
@@ -2895,11 +2895,12 @@ export class CodexClaudeAppServer {
       agentThreadId: context.childThreadId,
       agentPath: context.agentPath,
     }
-    // Codex cc 26.818 rejects `kind: completed` when replaying history. The
-    // live notification is useful to newer clients, but the terminal wait
-    // item and child turn already carry the durable completion state, so keep
-    // the persisted representation legacy-safe.
-    if (kind !== 'completed') this.store.appendItem(parentTurnId, item)
+    // The durable wait/child-turn state is enough while a modern peer is
+    // live. Persist only terminal activity for modern peers; replaying a
+    // persisted `started` marker after a same-process thread/read would make
+    // a completed child look active again. Legacy peers never receive the
+    // successful activity kinds and keep the existing interrupted marker.
+    if (kind !== 'started') this.store.appendItem(parentTurnId, item)
     this.emitItemLifecycle(peer, parentThreadId, parentTurnId, item)
   }
 

--- a/src/server.mts
+++ b/src/server.mts
@@ -123,6 +123,7 @@ type TurnItemsView = 'full' | 'summary' | 'notLoaded'
 
 interface SubagentContext {
   childThreadId: string
+  childTurnId: string
   waitItemId: string
   prompt: string
   subType: string | null
@@ -1730,6 +1731,7 @@ export class CodexClaudeAppServer {
             const childThreadId = newId()
             const agentNickname = `agent-${childThreadId.replace(/-/g, '').slice(0, 12)}`
             const agentRole = subType ?? 'general-purpose'
+            const childStartedAt = nowSeconds()
             const childThread: ThreadRecord = {
               id: childThreadId,
               sessionId: thread.sessionId,
@@ -1743,8 +1745,8 @@ export class CodexClaudeAppServer {
               modelProvider: thread.modelProvider,
               claudeSessionId: null,
               source: normalizeSessionSource(thread.source),
-              createdAt: nowSeconds(),
-              updatedAt: nowSeconds(),
+              createdAt: childStartedAt,
+              updatedAt: childStartedAt,
               status: { type: 'active', activeFlags: [] },
               approvalPolicy: thread.approvalPolicy,
               sandboxMode: thread.sandboxMode,
@@ -1764,6 +1766,35 @@ export class CodexClaudeAppServer {
               codexSessionId: null,
             }
             this.store.upsertThread(childThread)
+            const childTurn: TurnRecord = {
+              id: newId(),
+              threadId: childThreadId,
+              status: 'inProgress',
+              startedAt: childStartedAt,
+              completedAt: null,
+              durationMs: null,
+              items: [
+                {
+                  type: 'userMessage',
+                  id: newId(),
+                  content: [{ type: 'text', text: promptText, text_elements: [] }],
+                },
+              ],
+              diff: '',
+              error: null,
+            }
+            this.store.upsertTurn(childTurn)
+            this.notify(peer, {
+              method: 'thread/started',
+              params: { thread: this.toThread(childThread, []) },
+            })
+            this.notify(peer, {
+              method: 'turn/started',
+              params: {
+                threadId: childThreadId,
+                turn: this.toLifecycleTurn(childTurn),
+              },
+            })
             recordRunEvent('subagent.spawned', {
               parentThreadId: thread.id,
               parentTurnId: turn.id,
@@ -1856,6 +1887,7 @@ export class CodexClaudeAppServer {
             itemIds.set(event.toolUseId, waitId)
             subagentContexts.set(event.toolUseId, {
               childThreadId,
+              childTurnId: childTurn.id,
               waitItemId: waitId,
               prompt: promptText,
               subType,
@@ -1882,36 +1914,14 @@ export class CodexClaudeAppServer {
             const parsed = parseSubagentTrailer(rawResultText)
             const resultText = parsed.cleanText
 
-            // Materialize a one-turn transcript on the child thread so the
-            // Codex App can drill in from the parent collabAgentToolCall.
-            const childTurn: TurnRecord = {
-              id: newId(),
-              threadId: ctx.childThreadId,
-              status: event.isError ? 'failed' : 'completed',
-              startedAt: nowSeconds(),
-              completedAt: nowSeconds(),
-              durationMs: parsed.usage?.durationMs ?? 0,
-              items: [
-                {
-                  type: 'userMessage',
-                  id: newId(),
-                  content: [{ type: 'text', text: ctx.prompt, text_elements: [] }],
-                },
-                {
-                  type: 'agentMessage',
-                  id: newId(),
-                  text: resultText,
-                  phase: null,
-                  memoryCitation: null,
-                },
-              ],
-              diff: '',
-              error: event.isError ? { message: 'subagent failed' } : null,
-              apiDurationMs: parsed.usage?.durationMs ?? null,
-              numTurns: parsed.usage?.toolUses ?? null,
-              costUsd: null,
-            }
-            this.store.upsertTurn(childTurn)
+            const childTurn = this.completeSubagentChildTurn(
+              peer,
+              ctx,
+              resultText,
+              event.isError ? 'failed' : 'completed',
+              event.isError ? { message: 'subagent failed' } : null,
+              parsed.usage?.durationMs ?? null,
+            )
             recordRunEvent('subagent.completed', {
               parentThreadId: thread.id,
               parentTurnId: turn.id,
@@ -1922,7 +1932,6 @@ export class CodexClaudeAppServer {
             })
             const childThread = this.store.getThread(ctx.childThreadId)
             if (childThread) {
-              childThread.status = { type: 'idle' }
               childThread.updatedAt = nowSeconds()
               // Replace our synthetic `agent-{hex}` nickname with the SDK-
               // assigned id so SendMessage / SubAgent navigation in the App
@@ -2485,6 +2494,94 @@ export class CodexClaudeAppServer {
     })
   }
 
+  private completeSubagentChildTurn(
+    peer: RpcPeer,
+    context: SubagentContext,
+    resultText: string,
+    status: 'completed' | 'failed',
+    error: unknown | null,
+    durationMs: number | null = null,
+  ): TurnRecord {
+    let childTurn = this.store.getTurn(context.childTurnId)
+    if (!childTurn) {
+      childTurn = {
+        id: context.childTurnId,
+        threadId: context.childThreadId,
+        status: 'inProgress',
+        startedAt: nowSeconds(),
+        completedAt: null,
+        durationMs: null,
+        items: [
+          {
+            type: 'userMessage',
+            id: newId(),
+            content: [{ type: 'text', text: context.prompt, text_elements: [] }],
+          },
+        ],
+        diff: '',
+        error: null,
+      }
+      this.store.upsertTurn(childTurn)
+    }
+
+    const agentItemId = newId()
+    const startedItem: ThreadItem = {
+      type: 'agentMessage',
+      id: agentItemId,
+      text: '',
+      phase: null,
+      memoryCitation: null,
+    }
+    this.store.appendItem(childTurn.id, startedItem)
+    this.notify(peer, {
+      method: 'item/started',
+      params: {
+        threadId: context.childThreadId,
+        turnId: childTurn.id,
+        item: startedItem,
+        startedAtMs: nowMillis(),
+      },
+    })
+
+    const completedItem: ThreadItem = { ...startedItem, text: resultText }
+    this.store.updateItem(childTurn.id, agentItemId, () => completedItem)
+    if (resultText) {
+      this.notify(peer, {
+        method: 'item/agentMessage/delta',
+        params: {
+          threadId: context.childThreadId,
+          turnId: childTurn.id,
+          itemId: agentItemId,
+          delta: resultText,
+        },
+      })
+    }
+    this.notify(peer, {
+      method: 'item/completed',
+      params: {
+        threadId: context.childThreadId,
+        turnId: childTurn.id,
+        item: completedItem,
+        completedAtMs: nowMillis(),
+      },
+    })
+
+    const completed = this.store.completeTurn(childTurn.id, status, error) ?? childTurn
+    if (durationMs != null) {
+      completed.durationMs = durationMs
+      this.store.upsertTurn(completed)
+    }
+    this.setThreadStatus(peer, context.childThreadId, { type: 'idle' })
+    this.notify(peer, {
+      method: 'turn/completed',
+      params: {
+        threadId: context.childThreadId,
+        turn: this.toLifecycleTurn(completed),
+      },
+    })
+    return completed
+  }
+
   private finalizeOrphanedSubagents(
     peer: RpcPeer,
     thread: ThreadRecord,
@@ -2499,38 +2596,9 @@ export class CodexClaudeAppServer {
       if (!context) continue
 
       const message = 'Subagent ended without a terminal task result.'
-      const now = nowSeconds()
-      const childTurn: TurnRecord = {
-        id: newId(),
-        threadId: context.childThreadId,
-        status: 'failed',
-        startedAt: now,
-        completedAt: now,
-        durationMs: 0,
-        items: [
-          {
-            type: 'userMessage',
-            id: newId(),
-            content: [{ type: 'text', text: context.prompt, text_elements: [] }],
-          },
-          {
-            type: 'agentMessage',
-            id: newId(),
-            text: message,
-            phase: null,
-            memoryCitation: null,
-          },
-        ],
-        diff: '',
-        error: { message },
-      }
-      this.store.upsertTurn(childTurn)
-      const childThread = this.store.getThread(context.childThreadId)
-      if (childThread) {
-        childThread.status = { type: 'idle' }
-        childThread.updatedAt = now
-        this.store.upsertThread(childThread)
-      }
+      const childTurn = this.completeSubagentChildTurn(peer, context, message, 'failed', {
+        message,
+      })
       recordRunEvent('subagent.completed', {
         parentThreadId: thread.id,
         parentTurnId: turn.id,

--- a/src/server.mts
+++ b/src/server.mts
@@ -114,11 +114,27 @@ import {
   resolveClaudeModel,
   textFromInput,
 } from './util.mjs'
+import { parseWorkflowCommand } from './workflow-command.mjs'
 import { maybeCreateThreadWorktree } from './worktree.mjs'
 
 const execFileAsync = promisify(execFile)
 
 type TurnItemsView = 'full' | 'summary' | 'notLoaded'
+
+interface SubagentContext {
+  childThreadId: string
+  waitItemId: string
+  prompt: string
+  subType: string | null
+}
+
+interface ActiveSubagentState {
+  peer: RpcPeer
+  thread: ThreadRecord
+  turn: TurnRecord
+  contexts: Map<string, SubagentContext>
+  active: Set<string>
+}
 
 function turnItemsView(value: unknown): TurnItemsView {
   if (value === 'full' || value === 'summary' || value === 'notLoaded') return value
@@ -132,6 +148,7 @@ export class CodexClaudeAppServer {
   >()
   private activePeerByThread = new Map<string, RpcPeer>()
   private activeTurnByThread = new Map<string, string>()
+  private subagentStateByTurn = new Map<string, ActiveSubagentState>()
   private fuzzySessions = new Map<string, { roots: string[] }>()
   private commandSessionAllow = new Map<string, Set<string>>()
   private commandProcesses = new Map<string, ChildProcess>()
@@ -1282,6 +1299,7 @@ export class CodexClaudeAppServer {
     // inline next to the user message instead of losing them.
     const { textPrompt, images } = extractImageInputs(input)
     const prompt = textPrompt || textFromInput(input)
+    const workflowCommand = parseWorkflowCommand(prompt)
     if (typeof params.cwd === 'string' && params.cwd.length > 0) thread.cwd = params.cwd
     const model = modelFromParams(params, thread.model)
     const reasoningEffort = reasoningEffortFromParams(params, thread.reasoningEffort)
@@ -1352,12 +1370,18 @@ export class CodexClaudeAppServer {
           params: { threadId, turnId, item, completedAtMs: nowMillis() },
         })
       }
+      if (params.outputSchema == null && workflowCommand?.type === 'list') {
+        this.completeWorkflowListTurn(peer, thread, turn)
+        return
+      }
       // Carry parsed images through the params bag so runRuntimeTurn can hand
       // them to the runtime context without re-parsing user input.
       void this.runRuntimeTurn(peer, thread, turn, prompt, {
         ...params,
         _imageInputs: images,
       }).catch((error) => {
+        const current = this.store.getTurn(turnId)
+        if (current && current.status !== 'inProgress') return
         const completed =
           this.store.completeTurn(turnId, 'failed', { message: error.message }) ?? turn
         this.notify(peer, {
@@ -1373,6 +1397,109 @@ export class CodexClaudeAppServer {
       })
     })
     return { turn: publicTurn }
+  }
+
+  private completeWorkflowListTurn(peer: RpcPeer, thread: ThreadRecord, turn: TurnRecord): void {
+    const itemId = newId()
+    const emptyItem: ThreadItem = {
+      type: 'agentMessage',
+      id: itemId,
+      text: '',
+      phase: null,
+      memoryCitation: null,
+    }
+    this.store.appendItem(turn.id, emptyItem)
+    this.notify(peer, {
+      method: 'item/started',
+      params: { threadId: thread.id, turnId: turn.id, item: emptyItem, startedAtMs: nowMillis() },
+    })
+
+    const text = this.workflowListText(thread.id, turn.id)
+    const completedItem: ThreadItem = { ...emptyItem, text }
+    this.store.updateItem(turn.id, itemId, () => completedItem)
+    this.notify(peer, {
+      method: 'item/agentMessage/delta',
+      params: { threadId: thread.id, turnId: turn.id, itemId, delta: text },
+    })
+    this.notify(peer, {
+      method: 'item/completed',
+      params: {
+        threadId: thread.id,
+        turnId: turn.id,
+        item: completedItem,
+        completedAtMs: nowMillis(),
+      },
+    })
+
+    const completed = this.store.completeTurn(turn.id, 'completed') ?? turn
+    recordRunEvent('turn.completed', {
+      threadId: thread.id,
+      turnId: turn.id,
+      runtimeBackend: thread.runtimeBackend,
+      durationMs: completed.durationMs,
+      command: 'workflows.list',
+    })
+    this.clearActiveTurn(thread.id)
+    this.setThreadStatus(peer, thread.id, { type: 'idle' })
+    this.notify(peer, {
+      method: 'turn/completed',
+      params: { threadId: thread.id, turn: this.toLifecycleTurn(completed) },
+    })
+  }
+
+  private workflowListText(threadId: string, currentTurnId: string): string {
+    const runs = this.store
+      .listTurns(threadId)
+      .filter((turn) => turn.id !== currentTurnId)
+      .map((turn) => {
+        const userItem = turn.items.find((item) => item.type === 'userMessage')
+        const prompt = userItem?.type === 'userMessage' ? textFromInput(userItem.content) : ''
+        const command = parseWorkflowCommand(prompt)
+        if (command?.type !== 'run') return null
+        const childIds = new Set<string>()
+        for (const item of turn.items) {
+          if (item.type !== 'collabAgentToolCall' || item.tool !== 'spawnAgent') continue
+          for (const childId of item.receiverThreadIds) childIds.add(childId)
+        }
+        const agents = Array.from(childIds).map((childId) => {
+          const child = this.store.getThread(childId)
+          const latestTurn = this.store.listTurns(childId).at(-1)
+          return {
+            nickname: child?.agentNickname ?? childId.slice(0, 12),
+            role: child?.agentRole ?? 'subagent',
+            status: latestTurn?.status ?? child?.status.type ?? 'unknown',
+          }
+        })
+        return { turn, prompt: command.prompt, agents }
+      })
+      .filter((run): run is NonNullable<typeof run> => run !== null)
+      .reverse()
+      .slice(0, 20)
+
+    if (runs.length === 0) {
+      return [
+        'No workflow runs in this task.',
+        '',
+        'Start one with `/workflows <task>`. The adapter runs it through Claude ultracode and exposes its agents as reviewable Codex subagent tasks.',
+      ].join('\n')
+    }
+
+    const lines = ['Workflow runs in this task:']
+    for (const run of runs) {
+      const task = run.prompt.replace(/\s+/g, ' ').slice(0, 120)
+      lines.push(
+        `- ${run.turn.id.slice(0, 12)} · ${run.turn.status} · ${run.agents.length} agent(s) · ${task}`,
+      )
+      if (run.agents.length > 0) {
+        lines.push(
+          `  Agents: ${run.agents
+            .map((agent) => `${agent.nickname} (${agent.role}, ${agent.status})`)
+            .join(', ')}`,
+        )
+      }
+    }
+    lines.push('', 'Open the Agent items in the workflow turn to review each child task.')
+    return lines.join('\n')
   }
 
   private async runRuntimeTurn(
@@ -1394,10 +1521,7 @@ export class CodexClaudeAppServer {
     // Together they tell Codex App which child thread to navigate into and
     // give the user a live "agent is running" indicator instead of a single
     // collapsed item that goes silent for the duration of the subagent.
-    const subagentContexts = new Map<
-      string,
-      { childThreadId: string; waitItemId: string; prompt: string; subType: string | null }
-    >()
+    const subagentContexts = new Map<string, SubagentContext>()
     const activeSubagents = new Set<string>()
     // Track per-item start time so commandExecution / mcpToolCall items can
     // report a real durationMs in turn/completed (otherwise the App's status
@@ -1539,7 +1663,14 @@ export class CodexClaudeAppServer {
     // mock runtime handles everything regardless of model id — bypass the
     // codex-proxy override so unit tests stay deterministic.
     const isCodexThread = thread.runtimeBackend === 'codex' && process.env.CLAUDE_CODEX_MOCK !== '1'
-    await this.runtime.runTurn(
+    this.subagentStateByTurn.set(turn.id, {
+      peer,
+      thread,
+      turn,
+      contexts: subagentContexts,
+      active: activeSubagents,
+    })
+    const runtimeTurn = this.runtime.runTurn(
       {
         threadId: thread.id,
         turnId: turn.id,
@@ -2280,6 +2411,23 @@ export class CodexClaudeAppServer {
         },
       },
     )
+    await runtimeTurn.then(
+      () => {
+        if (this.store.getTurn(turn.id)?.status === 'inProgress') {
+          this.finalizeOrphanedSubagents(peer, thread, turn, subagentContexts, activeSubagents)
+        }
+        this.subagentStateByTurn.delete(turn.id)
+      },
+      (error: unknown) => {
+        if (this.store.getTurn(turn.id)?.status === 'inProgress') {
+          this.finalizeOrphanedSubagents(peer, thread, turn, subagentContexts, activeSubagents)
+        }
+        this.subagentStateByTurn.delete(turn.id)
+        throw error
+      },
+    )
+    const currentTurn = this.store.getTurn(turn.id)
+    if (currentTurn && currentTurn.status !== 'inProgress') return
 
     const finalDiff = await gitDiff(thread.cwd)
     if (finalDiff) {
@@ -2335,6 +2483,125 @@ export class CodexClaudeAppServer {
       method: 'turn/completed',
       params: { threadId: thread.id, turn: this.toLifecycleTurn(completed) },
     })
+  }
+
+  private finalizeOrphanedSubagents(
+    peer: RpcPeer,
+    thread: ThreadRecord,
+    turn: TurnRecord,
+    contexts: Map<string, SubagentContext>,
+    active: Set<string>,
+  ): void {
+    for (const toolUseId of Array.from(active)) {
+      const context = contexts.get(toolUseId)
+      active.delete(toolUseId)
+      contexts.delete(toolUseId)
+      if (!context) continue
+
+      const message = 'Subagent ended without a terminal task result.'
+      const now = nowSeconds()
+      const childTurn: TurnRecord = {
+        id: newId(),
+        threadId: context.childThreadId,
+        status: 'failed',
+        startedAt: now,
+        completedAt: now,
+        durationMs: 0,
+        items: [
+          {
+            type: 'userMessage',
+            id: newId(),
+            content: [{ type: 'text', text: context.prompt, text_elements: [] }],
+          },
+          {
+            type: 'agentMessage',
+            id: newId(),
+            text: message,
+            phase: null,
+            memoryCitation: null,
+          },
+        ],
+        diff: '',
+        error: { message },
+      }
+      this.store.upsertTurn(childTurn)
+      const childThread = this.store.getThread(context.childThreadId)
+      if (childThread) {
+        childThread.status = { type: 'idle' }
+        childThread.updatedAt = now
+        this.store.upsertThread(childThread)
+      }
+      recordRunEvent('subagent.completed', {
+        parentThreadId: thread.id,
+        parentTurnId: turn.id,
+        childThreadId: context.childThreadId,
+        childTurnId: childTurn.id,
+        status: 'failed',
+        agentRole: context.subType ?? 'general-purpose',
+      })
+
+      const waitEnd: ThreadItem = {
+        type: 'collabAgentToolCall',
+        id: context.waitItemId,
+        tool: 'wait',
+        status: 'failed',
+        senderThreadId: thread.id,
+        receiverThreadIds: [context.childThreadId],
+        prompt: null,
+        model: null,
+        reasoningEffort: null,
+        agentsStates: { [context.childThreadId]: { status: 'errored', message } },
+      }
+      this.store.updateItem(turn.id, context.waitItemId, () => waitEnd)
+      this.notify(peer, {
+        method: 'item/completed',
+        params: {
+          threadId: thread.id,
+          turnId: turn.id,
+          item: waitEnd,
+          completedAtMs: nowMillis(),
+        },
+      })
+
+      const closeId = newId()
+      const closeBegin: ThreadItem = {
+        type: 'collabAgentToolCall',
+        id: closeId,
+        tool: 'closeAgent',
+        status: 'inProgress',
+        senderThreadId: thread.id,
+        receiverThreadIds: [context.childThreadId],
+        prompt: null,
+        model: null,
+        reasoningEffort: null,
+        agentsStates: {},
+      }
+      this.store.appendItem(turn.id, closeBegin)
+      this.notify(peer, {
+        method: 'item/started',
+        params: {
+          threadId: thread.id,
+          turnId: turn.id,
+          item: closeBegin,
+          startedAtMs: nowMillis(),
+        },
+      })
+      const closeEnd: ThreadItem = {
+        ...closeBegin,
+        status: 'failed',
+        agentsStates: { [context.childThreadId]: { status: 'errored', message } },
+      }
+      this.store.updateItem(turn.id, closeId, () => closeEnd)
+      this.notify(peer, {
+        method: 'item/completed',
+        params: {
+          threadId: thread.id,
+          turnId: turn.id,
+          item: closeEnd,
+          completedAtMs: nowMillis(),
+        },
+      })
+    }
   }
 
   private async requestApproval(
@@ -2438,11 +2705,22 @@ export class CodexClaudeAppServer {
     const threadId = stringOr(params.threadId, '')
     const requestedTurnId = stringOr(params.turnId, '')
     const activeTurnId = this.activeTurnByThread.get(threadId)
-    await this.runtime.interrupt(threadId)
+    const interrupting = this.runtime.interrupt(threadId)
     const turnId = activeTurnId || requestedTurnId
     if (turnId) {
       const turn = this.store.getTurn(turnId)
       if (turn?.status === 'inProgress') {
+        const subagents = this.subagentStateByTurn.get(turnId)
+        if (subagents) {
+          this.finalizeOrphanedSubagents(
+            subagents.peer,
+            subagents.thread,
+            subagents.turn,
+            subagents.contexts,
+            subagents.active,
+          )
+          this.subagentStateByTurn.delete(turnId)
+        }
         const completed =
           this.store.completeTurn(turnId, 'interrupted', { message: 'interrupted' }) ?? turn
         this.notify(peer, {
@@ -2453,6 +2731,7 @@ export class CodexClaudeAppServer {
     }
     this.clearActiveTurn(threadId)
     this.setThreadStatus(peer, threadId, { type: 'idle' })
+    await interrupting
     return {}
   }
 

--- a/src/server.mts
+++ b/src/server.mts
@@ -2576,7 +2576,7 @@ export class CodexClaudeAppServer {
       method: 'turn/completed',
       params: {
         threadId: context.childThreadId,
-        turn: this.toLifecycleTurn(completed),
+        turn: this.toCompletedTurn(completed),
       },
     })
     return completed
@@ -3691,15 +3691,33 @@ export class CodexClaudeAppServer {
   }
 
   private toThread(thread: ThreadRecord, turns: TurnRecord[] = []): unknown {
+    const agentNickname = nullIfEmpty(thread.agentNickname)
+    const agentRole = nullIfEmpty(thread.agentRole)
+    const parentThreadId = thread.threadSource === 'subagent' ? thread.forkedFromId : null
+    const source = parentThreadId
+      ? {
+          subAgent: {
+            thread_spawn: {
+              parent_thread_id: parentThreadId,
+              depth: this.subagentDepth(thread),
+              agent_path: null,
+              agent_nickname: agentNickname,
+              agent_role: agentRole,
+            },
+          },
+        }
+      : normalizeSessionSource(thread.source)
     return {
       id: thread.id,
       sessionId: thread.sessionId,
       forkedFromId: thread.forkedFromId,
+      parentThreadId,
       preview: thread.preview,
       ephemeral: thread.ephemeral,
       modelProvider: thread.modelProvider,
       createdAt: thread.createdAt,
       updatedAt: thread.updatedAt,
+      recencyAt: thread.updatedAt,
       status: thread.status,
       path: null,
       cwd: thread.cwd,
@@ -3708,14 +3726,28 @@ export class CodexClaudeAppServer {
       // `threadSource` (legacy `app_server`, empty string from a buggy write
       // path), coerce on the way out so the App's strict deserializer never
       // sees a value outside the wire enum.
-      source: normalizeSessionSource(thread.source),
+      source,
       threadSource: normalizeThreadSource(thread.threadSource),
-      agentNickname: nullIfEmpty(thread.agentNickname),
-      agentRole: nullIfEmpty(thread.agentRole),
+      agentNickname,
+      agentRole,
       gitInfo: null,
       name: thread.name,
       turns: turns.map((turn) => this.toTurn(turn)),
     }
+  }
+
+  private subagentDepth(thread: ThreadRecord): number {
+    let depth = thread.threadSource === 'subagent' ? 1 : 0
+    let ancestorId = thread.forkedFromId
+    const seen = new Set([thread.id])
+    while (ancestorId && !seen.has(ancestorId)) {
+      seen.add(ancestorId)
+      const ancestor = this.store.getThread(ancestorId)
+      if (!ancestor || ancestor.threadSource !== 'subagent') break
+      depth += 1
+      ancestorId = ancestor.forkedFromId
+    }
+    return depth
   }
 
   // Full turn payload for history reads (thread/read, turns/list) — carries the
@@ -3754,16 +3786,36 @@ export class CodexClaudeAppServer {
     }
   }
 
-  // Turn payload for the turn lifecycle surface (turn/start response,
-  // turn/started, turn/completed). The real codex app-server deliberately ships
-  // an empty `items` list with `itemsView: "notLoaded"` here: the App's timeline
-  // is driven by the item/* event stream, not by items embedded in these turn
-  // envelopes. Re-shipping the full item list risks duplicate rendering.
+  // Lightweight payload for turn/start, turn/started, and terminal paths that
+  // intentionally do not carry an assistant summary. The item stream drives
+  // the timeline; completed subagent turns use toCompletedTurn below.
   private toLifecycleTurn(turn: TurnRecord, items: ThreadItem[] = []): unknown {
     return {
       id: turn.id,
       items,
       itemsView: 'notLoaded',
+      status: turn.status,
+      error: turn.error,
+      startedAt: turn.startedAt,
+      completedAt: turn.completedAt,
+      durationMs: turn.durationMs,
+    }
+  }
+
+  // Codex includes the final assistant message in successful turn/completed
+  // notifications. Subagent pages depend on that summary because they can be
+  // opened with a metadata-only thread/read and may not replay prior deltas.
+  private toCompletedTurn(turn: TurnRecord): unknown {
+    const lastAgent =
+      turn.status === 'completed' && turn.error == null
+        ? turn.items.findLast(
+            (item) => item.type === 'agentMessage' && item.text.trim().length > 0,
+          )
+        : undefined
+    return {
+      id: turn.id,
+      items: lastAgent ? [lastAgent] : [],
+      itemsView: lastAgent ? 'summary' : 'notLoaded',
       status: turn.status,
       error: turn.error,
       startedAt: turn.startedAt,

--- a/src/server.mts
+++ b/src/server.mts
@@ -32,6 +32,7 @@ import {
   fileChangeFromTool,
   gitDiff,
   gitUntrackedDiff,
+  hasLegacyPermissionParams,
   isGitWorkTree,
   isNotAGitRepo,
   isSubagentToolName,
@@ -130,11 +131,21 @@ const execFileAsync = promisify(execFile)
 const DEFAULT_SUBAGENT_WATCHDOG_MS = 30 * 60 * 1000
 const MIN_SUBAGENT_WATCHDOG_MS = 100
 
+function isWorkflowToolName(value: string): boolean {
+  const name = value.trim().toLowerCase()
+  return name === 'workflow' || name === 'workflows'
+}
+
 function subagentWatchdogTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
   const raw = env.CLAUDE_CODEX_SUBAGENT_TIMEOUT_MS?.trim()
   if (!raw) return DEFAULT_SUBAGENT_WATCHDOG_MS
   const parsed = Number(raw)
-  if (!Number.isFinite(parsed) || parsed <= 0) return 0
+  // Zero is the documented opt-out. Invalid and negative values must fall
+  // back to the bounded default rather than silently reintroducing an
+  // unbounded loading state.
+  if (!Number.isFinite(parsed)) return DEFAULT_SUBAGENT_WATCHDOG_MS
+  if (parsed === 0) return 0
+  if (parsed < 0) return DEFAULT_SUBAGENT_WATCHDOG_MS
   return Math.max(MIN_SUBAGENT_WATCHDOG_MS, Math.floor(parsed))
 }
 
@@ -687,6 +698,7 @@ export class CodexClaudeAppServer {
         thread.approvalPolicy = permissionProfile.approvalPolicy
       if (permissionProfile?.sandboxMode) thread.sandboxMode = permissionProfile.sandboxMode
     } else {
+      if (hasLegacyPermissionParams(params)) thread.permissionProfileId = null
       if (typeof params.approvalPolicy === 'string')
         thread.approvalPolicy = normalizeApprovalPolicy(params.approvalPolicy)
       if (typeof params.sandbox === 'string')
@@ -749,7 +761,8 @@ export class CodexClaudeAppServer {
           ? normalizeSandboxMode(params.sandbox)
           : parent.sandboxMode),
       permissionProfileId:
-        permissionProfileIdFromParams(params) ?? parent.permissionProfileId ?? null,
+        permissionProfileIdFromParams(params) ??
+        (hasLegacyPermissionParams(params) ? null : parent.permissionProfileId ?? null),
       ephemeral: parent.ephemeral,
       threadSource:
         typeof params.threadSource === 'string'
@@ -1062,6 +1075,7 @@ export class CodexClaudeAppServer {
     const permissionProfileId = permissionProfileIdFromParams(params)
     const permissionProfile = permissionProfilePolicy(permissionProfileId)
     if (permissionProfileId) thread.permissionProfileId = permissionProfileId
+    else if (hasLegacyPermissionParams(params)) thread.permissionProfileId = null
     if (permissionProfile?.approvalPolicy) thread.approvalPolicy = permissionProfile.approvalPolicy
     if (permissionProfile?.sandboxMode) thread.sandboxMode = permissionProfile.sandboxMode
     if (typeof params.approvalPolicy === 'string' && !permissionProfile)
@@ -1452,6 +1466,7 @@ export class CodexClaudeAppServer {
         thread.approvalPolicy = permissionProfile.approvalPolicy
       if (permissionProfile?.sandboxMode) thread.sandboxMode = permissionProfile.sandboxMode
     } else {
+      if (hasLegacyPermissionParams(params)) thread.permissionProfileId = null
       if (typeof params.approvalPolicy === 'string')
         thread.approvalPolicy = normalizeApprovalPolicy(params.approvalPolicy)
       const requestedSandbox = sandboxFromTurnParams(params)
@@ -1671,6 +1686,11 @@ export class CodexClaudeAppServer {
     // parent state so Codex App retains the terminal snapshot.
     const subagentContexts = new Map<string, SubagentContext>()
     const activeSubagents = new Set<string>()
+    // A Workflow launch can be pending before it has produced a journal
+    // agent (or after its last projected agent has completed). Keep the
+    // watchdog armed for that whole async operation, not only while a child
+    // tool_use is present.
+    let workflowInFlight = false
     // Track per-item start time so commandExecution / mcpToolCall items can
     // report a real durationMs in turn/completed (otherwise the App's status
     // bar shows "—" for every command).
@@ -1836,7 +1856,12 @@ export class CodexClaudeAppServer {
       watchdogTimer = null
     }
     const armWatchdog = (): void => {
-      if (!watchdogPromise || watchdogTimer || !acceptRuntimeEvents || activeSubagents.size === 0)
+      if (
+        !watchdogPromise ||
+        watchdogTimer ||
+        !acceptRuntimeEvents ||
+        (activeSubagents.size === 0 && !workflowInFlight)
+      )
         return
       watchdogTimer = setTimeout(() => {
         watchdogTimer = null
@@ -2099,8 +2124,6 @@ export class CodexClaudeAppServer {
           }
           if (event.type === 'tool_result' && activeSubagents.has(event.toolUseId)) {
             const ctx = subagentContexts.get(event.toolUseId)
-            activeSubagents.delete(event.toolUseId)
-            subagentContexts.delete(event.toolUseId)
             if (!ctx) return
             const rawResultText = toolResultText(event.content)
             const collabStatus: 'completed' | 'failed' = event.isError ? 'failed' : 'completed'
@@ -2213,7 +2236,12 @@ export class CodexClaudeAppServer {
                 completedAtMs: nowMillis(),
               },
             })
-            if (activeSubagents.size === 0) disarmWatchdog()
+            // Keep the context discoverable until the child turn and wait
+            // item have both been persisted. If one of those operations throws,
+            // the outer settlement path can still finalize the child as failed.
+            activeSubagents.delete(event.toolUseId)
+            subagentContexts.delete(event.toolUseId)
+            if (activeSubagents.size === 0 && !workflowInFlight) disarmWatchdog()
             return
           }
           if (event.type === 'text_delta') {
@@ -2280,6 +2308,10 @@ export class CodexClaudeAppServer {
             return
           }
           if (event.type === 'tool_use') {
+            if (isWorkflowToolName(event.toolName)) {
+              workflowInFlight = true
+              armWatchdog()
+            }
             // Defense in depth against duplicate tool_use events for the same
             // tool_use_id. Claude SDK has been known to emit a block_start
             // event with an empty input AND a complete copy in the final
@@ -2343,6 +2375,7 @@ export class CodexClaudeAppServer {
             return
           }
           if (event.type === 'tool_result') {
+            if (event.toolUseId.startsWith('workflow-task:')) workflowInFlight = false
             const itemId = itemIds.get(event.toolUseId)
             if (!itemId) return
             const resultText = toolResultText(event.content)
@@ -2795,6 +2828,11 @@ export class CodexClaudeAppServer {
     context: SubagentContext,
     kind: 'started' | 'interacted' | 'interrupted' | 'completed',
   ): void {
+    // Codex cc 26.x treats a persisted started activity marker as liveness,
+    // but does not advertise a compatible terminal activity kind. The
+    // canonical spawnAgent/wait lifecycle remains available for discovery and
+    // review, so omit this optional marker for legacy peers.
+    if (!this.supportsCompletedSubagentActivity(peer) && kind !== 'interrupted') return
     const item: ThreadItem = {
       type: 'subAgentActivity',
       id: newId(),

--- a/src/server.mts
+++ b/src/server.mts
@@ -129,7 +129,6 @@ interface SubagentContext {
 }
 
 interface ActiveSubagentState {
-  peer: RpcPeer
   thread: ThreadRecord
   turn: TurnRecord
   contexts: Map<string, SubagentContext>
@@ -1664,7 +1663,6 @@ export class CodexClaudeAppServer {
     // codex-proxy override so unit tests stay deterministic.
     const isCodexThread = thread.runtimeBackend === 'codex' && process.env.CLAUDE_CODEX_MOCK !== '1'
     this.subagentStateByTurn.set(turn.id, {
-      peer,
       thread,
       turn,
       contexts: subagentContexts,
@@ -2217,6 +2215,7 @@ export class CodexClaudeAppServer {
                 params: { threadId: thread.id, turnId: turn.id, item, completedAtMs: nowMillis() },
               })
             const diff = await gitDiff(thread.cwd)
+            if (this.store.getTurn(turn.id)?.status !== 'inProgress') return
             if (diff) {
               this.store.updateTurnDiff(turn.id, diff)
               this.notify(peer, {
@@ -2430,6 +2429,7 @@ export class CodexClaudeAppServer {
     if (currentTurn && currentTurn.status !== 'inProgress') return
 
     const finalDiff = await gitDiff(thread.cwd)
+    if (this.store.getTurn(turn.id)?.status !== 'inProgress') return
     if (finalDiff) {
       this.store.updateTurnDiff(turn.id, finalDiff)
       this.notify(peer, {
@@ -2704,6 +2704,7 @@ export class CodexClaudeAppServer {
   private async turnInterrupt(peer: RpcPeer, params: Record<string, unknown>): Promise<unknown> {
     const threadId = stringOr(params.threadId, '')
     const requestedTurnId = stringOr(params.turnId, '')
+    this.activePeerByThread.set(threadId, peer)
     const activeTurnId = this.activeTurnByThread.get(threadId)
     const interrupting = this.runtime.interrupt(threadId)
     const turnId = activeTurnId || requestedTurnId
@@ -2713,7 +2714,7 @@ export class CodexClaudeAppServer {
         const subagents = this.subagentStateByTurn.get(turnId)
         if (subagents) {
           this.finalizeOrphanedSubagents(
-            subagents.peer,
+            peer,
             subagents.thread,
             subagents.turn,
             subagents.contexts,

--- a/src/server.mts
+++ b/src/server.mts
@@ -51,6 +51,7 @@ import {
   parseExitCodeFromResult,
   parseSubagentTrailer,
   parseWebSearchAction,
+  permissionProfileList,
   personalityPromptCue,
   readConfigReasoningEffort,
   reasoningEffortFromParams,
@@ -125,6 +126,7 @@ interface SubagentContext {
   childThreadId: string
   childTurnId: string
   waitItemId: string
+  agentPath: string
   prompt: string
   subType: string | null
 }
@@ -134,6 +136,13 @@ interface ActiveSubagentState {
   turn: TurnRecord
   contexts: Map<string, SubagentContext>
   active: Set<string>
+}
+
+interface PeerFeatures {
+  // Codex cc 26.818.61809 only accepts started/interacted/interrupted in the
+  // subAgentActivity schema. Newer clients may opt into the completed kind
+  // explicitly during initialize; keep the legacy wire shape otherwise.
+  supportsCompletedSubagentActivity: boolean
 }
 
 function turnItemsView(value: unknown): TurnItemsView {
@@ -147,6 +156,7 @@ export class CodexClaudeAppServer {
     { resolve: (value: unknown) => void; reject: (error: Error) => void }
   >()
   private activePeerByThread = new Map<string, RpcPeer>()
+  private peerFeatures = new WeakMap<RpcPeer, PeerFeatures>()
   private activeTurnByThread = new Map<string, string>()
   private subagentStateByTurn = new Map<string, ActiveSubagentState>()
   private fuzzySessions = new Map<string, { roots: string[] }>()
@@ -261,6 +271,16 @@ export class CodexClaudeAppServer {
       case 'initialize': {
         const initParams = asRecord(params)
         const clientInfo = asRecord(initParams.clientInfo)
+        const capabilities = asRecord(initParams.capabilities)
+        const declaredActivityKinds = Array.isArray(capabilities.subAgentActivityKinds)
+          ? capabilities.subAgentActivityKinds
+          : []
+        this.peerFeatures.set(peer, {
+          supportsCompletedSubagentActivity:
+            capabilities.subAgentActivityCompleted === true ||
+            declaredActivityKinds.includes('completed') ||
+            process.env.CLAUDE_CODEX_SUBAGENT_COMPLETED === '1',
+        })
         // Push the account snapshot + MCP server statuses right after handshake
         // so the App's sidebar avatar and MCP panel populate without waiting
         // for the next polling cycle. Without these the avatar stays "signed
@@ -390,6 +410,8 @@ export class CodexClaudeAppServer {
         }
       case 'experimentalFeature/list':
         return { data: [], nextCursor: null }
+      case 'permissionProfile/list':
+        return permissionProfileList(asRecord(params))
       case 'experimentalFeature/enablement/set':
         return { enablement: asRecord(asRecord(params).enablement) }
       case 'collaborationMode/list':
@@ -1538,14 +1560,10 @@ export class CodexClaudeAppServer {
     let agentItemId: string | null = null
     let reasoningItemId: string | null = null
     const commandOutputSeen = new Set<string>()
-    // Codex's native subagent rendering is a sequence of three
-    // collabAgentToolCall lifecycle pairs in the parent timeline:
-    //   spawnAgent (begin → end)  – "spawning the agent"
-    //   wait        (begin → end)  – the agent is working (covers runtime)
-    //   closeAgent (begin → end)  – the agent finished
-    // Together they tell Codex App which child thread to navigate into and
-    // give the user a live "agent is running" indicator instead of a single
-    // collapsed item that goes silent for the duration of the subagent.
+    // MultiAgent V2 uses subAgentActivity for display/liveness and the
+    // spawnAgent/wait tool calls for the structured timeline. A naturally
+    // completed child is not closed again: wait/completed must remain the last
+    // parent state so Codex App retains the terminal snapshot.
     const subagentContexts = new Map<string, SubagentContext>()
     const activeSubagents = new Set<string>()
     // Track per-item start time so commandExecution / mcpToolCall items can
@@ -1737,9 +1755,8 @@ export class CodexClaudeAppServer {
               return
           }
           if (event.type === 'tool_use' && isSubagentToolName(event.toolName)) {
-            // Spawn the ephemeral subagent thread, then mirror Codex's native
-            // 3-stage timeline: `spawnAgent` (begin+end), `wait` (begin only,
-            // closes when the Task tool_result lands), and later `closeAgent`.
+            // Spawn the ephemeral child, then mirror MultiAgent V2: a
+            // subAgentActivity started item plus spawnAgent/wait tool state.
             //
             // Concept alignment: Claude's `subagent_type` (e.g. "general-
             // purpose") is the same idea as Codex's `agentRole`; we also
@@ -1755,6 +1772,7 @@ export class CodexClaudeAppServer {
               typeof event.input.model === 'string' ? event.input.model : thread.model
             const childThreadId = newId()
             const agentNickname = `agent-${childThreadId.replace(/-/g, '').slice(0, 12)}`
+            const agentPath = `/root/${agentNickname}`
             const agentRole = subType ?? 'general-purpose'
             const childStartedAt = nowSeconds()
             const childThread: ThreadRecord = {
@@ -1820,6 +1838,13 @@ export class CodexClaudeAppServer {
                 turn: this.toLifecycleTurn(childTurn),
               },
             })
+            // The bundled Codex cc client creates a child conversation from
+            // thread/started with an empty turn and treats the history as
+            // loaded while the child is live. Replay the persisted prompt as
+            // a normal item lifecycle so the child page has its Prompt even
+            // when it is opened before the first response token arrives.
+            const childPrompt = childTurn.items.find((item) => item.type === 'userMessage')
+            if (childPrompt) this.emitItemLifecycle(peer, childThreadId, childTurn.id, childPrompt)
             recordRunEvent('subagent.spawned', {
               parentThreadId: thread.id,
               parentTurnId: turn.id,
@@ -1881,11 +1906,20 @@ export class CodexClaudeAppServer {
                 completedAtMs: nowMillis(),
               },
             })
-
-            // Stage 2 — wait (begin only; this is the long phase that gives
-            // Codex App its "agent is working" indicator while the subagent
-            // runs. It closes when the Task tool_result arrives.)
             const waitId = newId()
+            const subagentContext: SubagentContext = {
+              childThreadId,
+              childTurnId: childTurn.id,
+              waitItemId: waitId,
+              agentPath,
+              prompt: promptText,
+              subType,
+            }
+            this.emitSubagentActivity(peer, thread.id, turn.id, subagentContext, 'started')
+
+            // Wait begins after the activity item; this is the long phase that
+            // gives Codex App its "agent is working" indicator while the
+            // subagent runs. It closes when the Task tool_result arrives.
             const waitBegin: ThreadItem = {
               type: 'collabAgentToolCall',
               id: waitId,
@@ -1910,13 +1944,7 @@ export class CodexClaudeAppServer {
             })
 
             itemIds.set(event.toolUseId, waitId)
-            subagentContexts.set(event.toolUseId, {
-              childThreadId,
-              childTurnId: childTurn.id,
-              waitItemId: waitId,
-              prompt: promptText,
-              subType,
-            })
+            subagentContexts.set(event.toolUseId, subagentContext)
             activeSubagents.add(event.toolUseId)
             return
           }
@@ -1965,6 +1993,21 @@ export class CodexClaudeAppServer {
               this.store.upsertThread(childThread)
             }
 
+            // The child completion activity arrives before wait/completed in
+            // native V2. The installed Codex cc schema predates the
+            // `completed` activity kind, so only send it when the client
+            // explicitly advertises support; the wait terminal snapshot is
+            // sufficient for legacy reducers.
+            if (event.isError || this.supportsCompletedSubagentActivity(peer)) {
+              this.emitSubagentActivity(
+                peer,
+                thread.id,
+                turn.id,
+                ctx,
+                event.isError ? 'interrupted' : 'completed',
+              )
+            }
+
             // Push the subagent's token usage as a Codex-native
             // thread/tokenUsage/updated notification on the CHILD thread
             // (App's status bar reads from this) and roll the totals into
@@ -2011,61 +2054,13 @@ export class CodexClaudeAppServer {
               reasoningEffort: null,
               agentsStates: { [ctx.childThreadId]: { status: agentStatus, message: null } },
             }
-            this.store.updateItem(turn.id, ctx.waitItemId, () => waitEnd)
+            this.store.updateItemAndMoveToEnd(turn.id, ctx.waitItemId, () => waitEnd)
             this.notify(peer, {
               method: 'item/completed',
               params: {
                 threadId: thread.id,
                 turnId: turn.id,
                 item: waitEnd,
-                completedAtMs: nowMillis(),
-              },
-            })
-
-            // Stage 3 — closeAgent (begin + end emitted together; the SDK has
-            // already torn down the subagent by the time we get the result).
-            const closeId = newId()
-            const closeBegin: ThreadItem = {
-              type: 'collabAgentToolCall',
-              id: closeId,
-              tool: 'closeAgent',
-              status: 'inProgress',
-              senderThreadId: thread.id,
-              receiverThreadIds: [ctx.childThreadId],
-              prompt: null,
-              model: null,
-              reasoningEffort: null,
-              agentsStates: {},
-            }
-            this.store.appendItem(turn.id, closeBegin)
-            this.notify(peer, {
-              method: 'item/started',
-              params: {
-                threadId: thread.id,
-                turnId: turn.id,
-                item: closeBegin,
-                startedAtMs: nowMillis(),
-              },
-            })
-            const closeEnd: ThreadItem = {
-              type: 'collabAgentToolCall',
-              id: closeId,
-              tool: 'closeAgent',
-              status: collabStatus,
-              senderThreadId: thread.id,
-              receiverThreadIds: [ctx.childThreadId],
-              prompt: null,
-              model: null,
-              reasoningEffort: null,
-              agentsStates: { [ctx.childThreadId]: { status: agentStatus, message: null } },
-            }
-            this.store.updateItem(turn.id, closeId, () => closeEnd)
-            this.notify(peer, {
-              method: 'item/completed',
-              params: {
-                threadId: thread.id,
-                turnId: turn.id,
-                item: closeEnd,
                 completedAtMs: nowMillis(),
               },
             })
@@ -2607,6 +2602,57 @@ export class CodexClaudeAppServer {
     return completed
   }
 
+  private emitSubagentActivity(
+    peer: RpcPeer,
+    parentThreadId: string,
+    parentTurnId: string,
+    context: SubagentContext,
+    kind: 'started' | 'interacted' | 'interrupted' | 'completed',
+  ): void {
+    const item: ThreadItem = {
+      type: 'subAgentActivity',
+      id: newId(),
+      kind,
+      agentThreadId: context.childThreadId,
+      agentPath: context.agentPath,
+    }
+    this.store.appendItem(parentTurnId, item)
+    this.emitItemLifecycle(peer, parentThreadId, parentTurnId, item)
+  }
+
+  private emitItemLifecycle(
+    peer: RpcPeer,
+    threadId: string,
+    turnId: string,
+    item: ThreadItem,
+  ): void {
+    const startedAtMs = nowMillis()
+    this.notify(peer, {
+      method: 'item/started',
+      params: {
+        threadId,
+        turnId,
+        item,
+        startedAtMs,
+      },
+    })
+    this.notify(peer, {
+      method: 'item/completed',
+      params: {
+        threadId,
+        turnId,
+        item,
+        completedAtMs: nowMillis(),
+      },
+    })
+  }
+
+  private supportsCompletedSubagentActivity(peer: RpcPeer): boolean {
+    if (process.env.CLAUDE_CODEX_SUBAGENT_COMPLETED === '1') return true
+    if (process.env.CLAUDE_CODEX_SUBAGENT_COMPLETED === '0') return false
+    return this.peerFeatures.get(peer)?.supportsCompletedSubagentActivity === true
+  }
+
   private finalizeOrphanedSubagents(
     peer: RpcPeer,
     thread: ThreadRecord,
@@ -2633,6 +2679,8 @@ export class CodexClaudeAppServer {
         agentRole: context.subType ?? 'general-purpose',
       })
 
+      this.emitSubagentActivity(peer, thread.id, turn.id, context, 'interrupted')
+
       const waitEnd: ThreadItem = {
         type: 'collabAgentToolCall',
         id: context.waitItemId,
@@ -2645,52 +2693,13 @@ export class CodexClaudeAppServer {
         reasoningEffort: null,
         agentsStates: { [context.childThreadId]: { status: 'errored', message } },
       }
-      this.store.updateItem(turn.id, context.waitItemId, () => waitEnd)
+      this.store.updateItemAndMoveToEnd(turn.id, context.waitItemId, () => waitEnd)
       this.notify(peer, {
         method: 'item/completed',
         params: {
           threadId: thread.id,
           turnId: turn.id,
           item: waitEnd,
-          completedAtMs: nowMillis(),
-        },
-      })
-
-      const closeId = newId()
-      const closeBegin: ThreadItem = {
-        type: 'collabAgentToolCall',
-        id: closeId,
-        tool: 'closeAgent',
-        status: 'inProgress',
-        senderThreadId: thread.id,
-        receiverThreadIds: [context.childThreadId],
-        prompt: null,
-        model: null,
-        reasoningEffort: null,
-        agentsStates: {},
-      }
-      this.store.appendItem(turn.id, closeBegin)
-      this.notify(peer, {
-        method: 'item/started',
-        params: {
-          threadId: thread.id,
-          turnId: turn.id,
-          item: closeBegin,
-          startedAtMs: nowMillis(),
-        },
-      })
-      const closeEnd: ThreadItem = {
-        ...closeBegin,
-        status: 'failed',
-        agentsStates: { [context.childThreadId]: { status: 'errored', message } },
-      }
-      this.store.updateItem(turn.id, closeId, () => closeEnd)
-      this.notify(peer, {
-        method: 'item/completed',
-        params: {
-          threadId: thread.id,
-          turnId: turn.id,
-          item: closeEnd,
           completedAtMs: nowMillis(),
         },
       })
@@ -3734,6 +3743,7 @@ export class CodexClaudeAppServer {
       : normalizeSessionSource(thread.source)
     return {
       id: thread.id,
+      isPinned: false,
       sessionId: thread.sessionId,
       forkedFromId: thread.forkedFromId,
       parentThreadId,

--- a/src/server.mts
+++ b/src/server.mts
@@ -252,8 +252,13 @@ export class CodexClaudeAppServer {
   async stop(): Promise<void> {
     if (this.stopped) return
     this.stopped = true
-    await this.runtime.stop()
+    // Child turns are created directly from Task/Workflow events and are not
+    // registered in activeTurnByThread. Finalize them before aborting the
+    // runtime or closing SQLite, otherwise stdio EOF can leave child turns
+    // persisted as inProgress until a later restart recovery pass.
+    this.finalizeActiveSubagentsForShutdown('server stopped')
     this.completeActiveTurns('interrupted', { message: 'server stopped' })
+    await this.runtime.stop()
     this.store.close()
   }
 
@@ -1691,6 +1696,7 @@ export class CodexClaudeAppServer {
     // watchdog armed for that whole async operation, not only while a child
     // tool_use is present.
     let workflowInFlight = false
+    const workflowLaunchToolUseIds = new Set<string>()
     // Track per-item start time so commandExecution / mcpToolCall items can
     // report a real durationMs in turn/completed (otherwise the App's status
     // bar shows "—" for every command).
@@ -2309,6 +2315,7 @@ export class CodexClaudeAppServer {
           }
           if (event.type === 'tool_use') {
             if (isWorkflowToolName(event.toolName)) {
+              workflowLaunchToolUseIds.add(event.toolUseId)
               workflowInFlight = true
               armWatchdog()
             }
@@ -2375,7 +2382,10 @@ export class CodexClaudeAppServer {
             return
           }
           if (event.type === 'tool_result') {
-            if (event.toolUseId.startsWith('workflow-task:')) workflowInFlight = false
+            if (workflowLaunchToolUseIds.delete(event.toolUseId)) {
+              workflowInFlight = workflowLaunchToolUseIds.size > 0
+              if (activeSubagents.size === 0 && !workflowInFlight) disarmWatchdog()
+            }
             const itemId = itemIds.get(event.toolUseId)
             if (!itemId) return
             const resultText = toolResultText(event.content)
@@ -4114,6 +4124,10 @@ export class CodexClaudeAppServer {
   }
 
   private notify(peer: RpcPeer, notification: { method: string; params: unknown }): void {
+    // Shutdown intentionally suppresses wire notifications: the peer may
+    // already have closed, while persistence still needs to settle child and
+    // parent state without throwing on a broken pipe.
+    if (this.stopped) return
     const target = this.peerForParams(peer, notification.params)
     debugLog('rpc.notify', {
       peerId: target.id,
@@ -4181,6 +4195,30 @@ export class CodexClaudeAppServer {
       this.store.updateThreadStatus(threadId, { type: 'idle' })
     }
     this.activeTurnByThread.clear()
+  }
+
+  private finalizeActiveSubagentsForShutdown(message: string): void {
+    for (const [turnId, state] of this.subagentStateByTurn.entries()) {
+      const turn = this.store.getTurn(turnId)
+      if (!turn || turn.status !== 'inProgress') {
+        this.subagentStateByTurn.delete(turnId)
+        continue
+      }
+      const peer = this.activePeerByThread.get(state.thread.id) ?? {
+        id: 'shutdown',
+        send: () => {},
+        close: () => {},
+      }
+      this.finalizeOrphanedSubagents(
+        peer,
+        state.thread,
+        turn,
+        state.contexts,
+        state.active,
+        message,
+      )
+      this.subagentStateByTurn.delete(turnId)
+    }
   }
 
   private clearActiveTurn(threadId: string): void {

--- a/src/server.mts
+++ b/src/server.mts
@@ -752,7 +752,10 @@ export class CodexClaudeAppServer {
       typeof params.ancestorThreadId === 'string' && params.ancestorThreadId.length > 0
         ? params.ancestorThreadId
         : null
-    const sortKey = params.sortKey === 'created_at' ? 'created_at' : 'updated_at'
+    const sortKey =
+      params.sortKey === 'updated_at' || params.sortKey === 'recency_at'
+        ? params.sortKey
+        : 'created_at'
     const sortDirection = params.sortDirection === 'asc' ? 'asc' : 'desc'
     const threads = this.store.listThreads({
       archived: (params.archived as boolean | null | undefined) ?? null,

--- a/src/store.mts
+++ b/src/store.mts
@@ -59,6 +59,7 @@ export class SessionStore {
     this.ensureColumn('threads', 'reasoning_effort', 'TEXT')
     this.ensureColumn('threads', 'approval_policy', 'TEXT')
     this.ensureColumn('threads', 'sandbox_mode', 'TEXT')
+    this.ensureColumn('threads', 'permission_profile_id', 'TEXT')
     this.ensureColumn('threads', 'ephemeral', 'INTEGER NOT NULL DEFAULT 0')
     this.ensureColumn('threads', 'thread_source', 'TEXT')
     this.ensureColumn('threads', 'agent_role', 'TEXT')
@@ -112,9 +113,9 @@ export class SessionStore {
         INSERT INTO threads (
           id, session_id, forked_from_id, preview, name, archived, cwd, model, reasoning_effort,
           model_provider, claude_session_id, source, created_at, updated_at, status_json,
-          approval_policy, sandbox_mode, ephemeral, thread_source, agent_role, agent_nickname,
+          approval_policy, sandbox_mode, permission_profile_id, ephemeral, thread_source, agent_role, agent_nickname,
           base_instructions, developer_instructions, personality, runtime_backend, codex_session_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           session_id=excluded.session_id,
           forked_from_id=excluded.forked_from_id,
@@ -131,6 +132,7 @@ export class SessionStore {
           status_json=excluded.status_json,
           approval_policy=excluded.approval_policy,
           sandbox_mode=excluded.sandbox_mode,
+          permission_profile_id=excluded.permission_profile_id,
           ephemeral=excluded.ephemeral,
           thread_source=excluded.thread_source,
           agent_role=excluded.agent_role,
@@ -159,6 +161,7 @@ export class SessionStore {
         JSON.stringify(thread.status),
         thread.approvalPolicy,
         thread.sandboxMode,
+        thread.permissionProfileId ?? null,
         thread.ephemeral ? 1 : 0,
         thread.threadSource,
         thread.agentRole,
@@ -462,14 +465,37 @@ export class SessionStore {
       updateThread.run(JSON.stringify({ type: 'idle' }), completedAt, threadId)
     }
     const terminalRows = this.db
-      .prepare('SELECT id, items_json FROM turns WHERE status <> ?')
-      .all('inProgress') as Array<{ id: string; items_json: string }>
+      .prepare('SELECT id, thread_id, status, items_json FROM turns WHERE status <> ?')
+      .all('inProgress') as Array<{
+      id: string
+      thread_id: string
+      status: TurnStatus
+      items_json: string
+    }>
     const updateItems = this.db.prepare('UPDATE turns SET items_json = ? WHERE id = ?')
+    const repairThreadIds = new Set<string>()
     for (const row of terminalRows) {
-      const itemsJson = this.terminalizeStaleItems(row.items_json, message)
+      // A successful legacy Codex cc turn intentionally persists only the
+      // `subAgentActivity: started` marker; its completed `wait` item is the
+      // terminal state. Preserve that history, while still clearing activity
+      // markers on genuinely failed/interrupted terminal turns.
+      const itemsJson = this.terminalizeStaleItems(
+        row.items_json,
+        message,
+        row.status !== 'completed',
+      )
       if (itemsJson === row.items_json) continue
       updateItems.run(itemsJson, row.id)
+      repairThreadIds.add(String(row.thread_id))
       recoveredCount += 1
+    }
+    const reconcileThread = this.db.prepare(
+      `UPDATE threads SET status_json = ?, updated_at = ?
+       WHERE id = ?
+         AND NOT EXISTS (SELECT 1 FROM turns WHERE thread_id = threads.id AND status = ?)`,
+    )
+    for (const threadId of repairThreadIds) {
+      reconcileThread.run(JSON.stringify({ type: 'idle' }), completedAt, threadId, 'inProgress')
     }
     return recoveredCount
   }
@@ -477,7 +503,11 @@ export class SessionStore {
   // A recovered turn is also replayed from its persisted item list. Clear any
   // item-level liveness markers so the App's spinner projection cannot keep a
   // child agent in `working` after the turn/thread has been terminalized.
-  private terminalizeStaleItems(itemsJson: string, message: string): string {
+  private terminalizeStaleItems(
+    itemsJson: string,
+    message: string,
+    terminalizeActivity = true,
+  ): string {
     let parsed: unknown
     try {
       parsed = JSON.parse(itemsJson)
@@ -489,7 +519,11 @@ export class SessionStore {
     const items = parsed.map((raw) => {
       if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return raw
       const item = raw as Record<string, unknown>
-      if (item.type === 'subAgentActivity' && item.kind === 'started') {
+      if (
+        terminalizeActivity &&
+        item.type === 'subAgentActivity' &&
+        (item.kind === 'started' || item.kind === 'interacted')
+      ) {
         return { ...item, kind: 'interrupted' }
       }
       if (item.type === 'collabAgentToolCall') {
@@ -555,6 +589,8 @@ export class SessionStore {
       status: JSON.parse(String(row.status_json)),
       approvalPolicy: row.approval_policy == null ? null : String(row.approval_policy),
       sandboxMode: row.sandbox_mode == null ? null : String(row.sandbox_mode),
+      permissionProfileId:
+        row.permission_profile_id == null ? null : String(row.permission_profile_id),
       ephemeral: Number(row.ephemeral ?? 0) === 1,
       threadSource: row.thread_source == null ? null : String(row.thread_source),
       agentRole: row.agent_role == null ? null : String(row.agent_role),

--- a/src/store.mts
+++ b/src/store.mts
@@ -425,15 +425,20 @@ export class SessionStore {
 
   recoverStaleInProgressTurns(message = 'server restarted before completing turn'): number {
     const rows = this.db
-      .prepare('SELECT id, thread_id, started_at FROM turns WHERE status = ?')
-      .all('inProgress') as Array<{ id: string; thread_id: string; started_at: number | null }>
+      .prepare('SELECT id, thread_id, started_at, items_json FROM turns WHERE status = ?')
+      .all('inProgress') as Array<{
+      id: string
+      thread_id: string
+      started_at: number | null
+      items_json: string
+    }>
     if (rows.length === 0) return 0
 
     const completedAt = nowSeconds()
     const errorJson = JSON.stringify({ message })
     const updateTurn = this.db.prepare(`
       UPDATE turns
-      SET status = ?, completed_at = ?, duration_ms = ?, error_json = ?
+      SET status = ?, completed_at = ?, duration_ms = ?, error_json = ?, items_json = ?
       WHERE id = ?
     `)
     const updateThread = this.db.prepare(
@@ -443,13 +448,70 @@ export class SessionStore {
     for (const row of rows) {
       const startedAt = row.started_at == null ? null : Number(row.started_at)
       const durationMs = startedAt == null ? null : Math.max(0, (completedAt - startedAt) * 1000)
-      updateTurn.run('interrupted', completedAt, durationMs, errorJson, row.id)
+      updateTurn.run(
+        'interrupted',
+        completedAt,
+        durationMs,
+        errorJson,
+        this.terminalizeStaleItems(row.items_json, message),
+        row.id,
+      )
       seenThreads.add(String(row.thread_id))
     }
     for (const threadId of seenThreads) {
       updateThread.run(JSON.stringify({ type: 'idle' }), completedAt, threadId)
     }
     return rows.length
+  }
+
+  // A recovered turn is also replayed from its persisted item list. Clear any
+  // item-level liveness markers so the App's spinner projection cannot keep a
+  // child agent in `working` after the turn/thread has been terminalized.
+  private terminalizeStaleItems(itemsJson: string, message: string): string {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(itemsJson)
+    } catch {
+      return itemsJson
+    }
+    if (!Array.isArray(parsed)) return itemsJson
+
+    const items = parsed.map((raw) => {
+      if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return raw
+      const item = raw as Record<string, unknown>
+      if (item.type === 'subAgentActivity' && item.kind === 'started') {
+        return { ...item, kind: 'interrupted' }
+      }
+      if (item.type === 'collabAgentToolCall') {
+        const agentsStates = item.agentsStates
+        const nextStates =
+          agentsStates && typeof agentsStates === 'object' && !Array.isArray(agentsStates)
+            ? Object.fromEntries(
+                Object.entries(agentsStates as Record<string, unknown>).map(
+                  ([threadId, rawState]) => {
+                    if (rawState == null || typeof rawState !== 'object' || Array.isArray(rawState))
+                      return [threadId, rawState]
+                    const state = rawState as Record<string, unknown>
+                    if (state.status !== 'pendingInit' && state.status !== 'running')
+                      return [threadId, state]
+                    return [
+                      threadId,
+                      { ...state, status: 'errored', message: state.message ?? message },
+                    ]
+                  },
+                ),
+              )
+            : agentsStates
+        return {
+          ...item,
+          ...(item.status === 'inProgress' ? { status: 'failed' } : {}),
+          agentsStates: nextStates,
+        }
+      }
+      if (item.status === 'inProgress') return { ...item, status: 'failed' }
+      return item
+    })
+    return JSON.stringify(items)
   }
 
   updateTurnDiff(turnId: string, diff: string): TurnRecord | null {

--- a/src/store.mts
+++ b/src/store.mts
@@ -186,20 +186,24 @@ export class SessionStore {
       parentThreadId?: string | null
       ancestorThreadId?: string | null
       sourceKinds?: string[]
-      sortKey?: 'created_at' | 'updated_at'
+      sortKey?: 'created_at' | 'updated_at' | 'recency_at'
       sortDirection?: 'asc' | 'desc'
     } = {},
   ): ThreadRecord[] {
     const limit = Math.max(1, Math.min(Number(options.limit ?? 50), 200))
     const archived = options.archived === true ? 1 : 0
-    const sortKey = options.sortKey === 'created_at' ? 'created_at' : 'updated_at'
+    const sortKey =
+      options.sortKey === 'updated_at' || options.sortKey === 'recency_at'
+        ? options.sortKey
+        : 'created_at'
+    const sortColumn = sortKey === 'created_at' ? 'created_at' : 'updated_at'
     const sortDirection = options.sortDirection === 'asc' ? 'ASC' : 'DESC'
     const cursor = options.cursor
       ? Number(options.cursor)
       : sortDirection === 'ASC'
         ? -1
         : Number.MAX_SAFE_INTEGER
-    const where = ['t.archived = ?', `t.${sortKey} ${sortDirection === 'ASC' ? '>' : '<'} ?`]
+    const where = ['t.archived = ?', `t.${sortColumn} ${sortDirection === 'ASC' ? '>' : '<'} ?`]
     const args: unknown[] = [archived, cursor]
     const parentThreadId = options.parentThreadId ?? null
     const ancestorThreadId = options.ancestorThreadId ?? null
@@ -216,7 +220,11 @@ export class SessionStore {
     if (sourceKinds.length > 0) {
       const predicates = sourceKinds.flatMap((kind) => {
         switch (kind) {
+          case 'subAgent':
+          case 'subAgentReview':
+          case 'subAgentCompact':
           case 'subAgentThreadSpawn':
+          case 'subAgentOther':
             return ["(t.thread_source = 'subagent' AND t.forked_from_id IS NOT NULL)"]
           case 'user':
             return ["t.thread_source = 'user'"]
@@ -239,8 +247,17 @@ export class SessionStore {
     // children, memory-consolidation runs) shouldn't appear in the user's
     // session list. Topology queries are the exception: Codex App asks for
     // subagent descendants without sending our legacy includeEphemeral flag.
+    const hasSubagentSourceFilter = sourceKinds.some((kind) =>
+      [
+        'subAgent',
+        'subAgentReview',
+        'subAgentCompact',
+        'subAgentThreadSpawn',
+        'subAgentOther',
+      ].includes(kind),
+    )
     const topologyQuery =
-      parentThreadId != null || ancestorThreadId != null || sourceKinds.length > 0
+      parentThreadId != null || ancestorThreadId != null || hasSubagentSourceFilter
     if (!options.includeEphemeral && !topologyQuery) where.push('t.ephemeral = 0')
 
     const cwdList = Array.isArray(options.cwd) ? options.cwd : options.cwd ? [options.cwd] : []
@@ -261,7 +278,7 @@ export class SessionStore {
     const queryArgs = ancestorThreadId == null ? args : [ancestorThreadId, ...args]
     const rows = this.db
       .prepare(
-        `${cte} SELECT t.* FROM threads t WHERE ${where.join(' AND ')} ORDER BY t.${sortKey} ${sortDirection}, t.id ${sortDirection} LIMIT ?`,
+        `${cte} SELECT t.* FROM threads t WHERE ${where.join(' AND ')} ORDER BY t.${sortColumn} ${sortDirection}, t.id ${sortDirection} LIMIT ?`,
       )
       .all(...queryArgs, limit)
     return rows.map((row: unknown) => this.rowToThread(row))

--- a/src/store.mts
+++ b/src/store.mts
@@ -389,6 +389,23 @@ export class SessionStore {
     return turn
   }
 
+  updateItemAndMoveToEnd(
+    turnId: string,
+    itemId: string,
+    updater: (item: ThreadItem) => ThreadItem,
+  ): TurnRecord | null {
+    const turn = this.getTurn(turnId)
+    if (!turn) return null
+    const index = turn.items.findIndex((item) => item.id === itemId)
+    if (index < 0) return turn
+    const current = turn.items[index]
+    if (!current) return turn
+    const updated = updater(jsonClone(current))
+    turn.items = [...turn.items.slice(0, index), ...turn.items.slice(index + 1), updated]
+    this.upsertTurn(turn)
+    return turn
+  }
+
   completeTurn(
     turnId: string,
     status: TurnStatus,

--- a/src/store.mts
+++ b/src/store.mts
@@ -221,11 +221,15 @@ export class SessionStore {
       const predicates = sourceKinds.flatMap((kind) => {
         switch (kind) {
           case 'subAgent':
+          case 'subAgentThreadSpawn':
+            return ["(t.thread_source = 'subagent' AND t.forked_from_id IS NOT NULL)"]
           case 'subAgentReview':
           case 'subAgentCompact':
-          case 'subAgentThreadSpawn':
           case 'subAgentOther':
-            return ["(t.thread_source = 'subagent' AND t.forked_from_id IS NOT NULL)"]
+            // These source kinds need a persisted discriminator that this
+            // adapter does not have. Fail closed instead of mislabelling a
+            // thread-spawn child as a review/compact/other subagent.
+            return []
           case 'user':
             return ["t.thread_source = 'user'"]
           case 'memoryConsolidation':
@@ -248,13 +252,7 @@ export class SessionStore {
     // session list. Topology queries are the exception: Codex App asks for
     // subagent descendants without sending our legacy includeEphemeral flag.
     const hasSubagentSourceFilter = sourceKinds.some((kind) =>
-      [
-        'subAgent',
-        'subAgentReview',
-        'subAgentCompact',
-        'subAgentThreadSpawn',
-        'subAgentOther',
-      ].includes(kind),
+      ['subAgent', 'subAgentThreadSpawn'].includes(kind),
     )
     const topologyQuery =
       parentThreadId != null || ancestorThreadId != null || hasSubagentSourceFilter

--- a/src/store.mts
+++ b/src/store.mts
@@ -432,8 +432,6 @@ export class SessionStore {
       started_at: number | null
       items_json: string
     }>
-    if (rows.length === 0) return 0
-
     const completedAt = nowSeconds()
     const errorJson = JSON.stringify({ message })
     const updateTurn = this.db.prepare(`
@@ -445,6 +443,7 @@ export class SessionStore {
       'UPDATE threads SET status_json = ?, updated_at = ? WHERE id = ?',
     )
     const seenThreads = new Set<string>()
+    let recoveredCount = 0
     for (const row of rows) {
       const startedAt = row.started_at == null ? null : Number(row.started_at)
       const durationMs = startedAt == null ? null : Math.max(0, (completedAt - startedAt) * 1000)
@@ -457,11 +456,22 @@ export class SessionStore {
         row.id,
       )
       seenThreads.add(String(row.thread_id))
+      recoveredCount += 1
     }
     for (const threadId of seenThreads) {
       updateThread.run(JSON.stringify({ type: 'idle' }), completedAt, threadId)
     }
-    return rows.length
+    const terminalRows = this.db
+      .prepare('SELECT id, items_json FROM turns WHERE status <> ?')
+      .all('inProgress') as Array<{ id: string; items_json: string }>
+    const updateItems = this.db.prepare('UPDATE turns SET items_json = ? WHERE id = ?')
+    for (const row of terminalRows) {
+      const itemsJson = this.terminalizeStaleItems(row.items_json, message)
+      if (itemsJson === row.items_json) continue
+      updateItems.run(itemsJson, row.id)
+      recoveredCount += 1
+    }
+    return recoveredCount
   }
 
   // A recovered turn is also replayed from its persisted item list. Clear any
@@ -472,9 +482,9 @@ export class SessionStore {
     try {
       parsed = JSON.parse(itemsJson)
     } catch {
-      return itemsJson
+      return '[]'
     }
-    if (!Array.isArray(parsed)) return itemsJson
+    if (!Array.isArray(parsed)) return '[]'
 
     const items = parsed.map((raw) => {
       if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return raw

--- a/src/store.mts
+++ b/src/store.mts
@@ -475,14 +475,15 @@ export class SessionStore {
     const updateItems = this.db.prepare('UPDATE turns SET items_json = ? WHERE id = ?')
     const repairThreadIds = new Set<string>()
     for (const row of terminalRows) {
-      // A successful legacy Codex cc turn intentionally persists only the
-      // `subAgentActivity: started` marker; its completed `wait` item is the
-      // terminal state. Preserve that history, while still clearing activity
-      // markers on genuinely failed/interrupted terminal turns.
+      // A successful legacy Codex cc turn may contain only a
+      // `subAgentActivity: started` marker. Remove that optional marker during
+      // recovery so the canonical spawnAgent/wait terminal state is used and
+      // a cold-opened child cannot be revived as working.
       const itemsJson = this.terminalizeStaleItems(
         row.items_json,
         message,
         row.status !== 'completed',
+        row.status === 'completed',
       )
       if (itemsJson === row.items_json) continue
       updateItems.run(itemsJson, row.id)
@@ -497,6 +498,22 @@ export class SessionStore {
     for (const threadId of repairThreadIds) {
       reconcileThread.run(JSON.stringify({ type: 'idle' }), completedAt, threadId, 'inProgress')
     }
+    // A crash can land between completeTurn() and the following
+    // setThreadStatus(..., idle). In that window every turn is already
+    // terminal, so the item JSON is unchanged and the repairThreadIds path
+    // above has nothing to trigger. Reconcile those active threads directly;
+    // never touch a thread that still owns an in-progress turn.
+    const reconcileTerminalActiveThreads = this.db.prepare(
+      `UPDATE threads SET status_json = ?, updated_at = ?
+       WHERE json_extract(status_json, '$.type') = 'active'
+         AND NOT EXISTS (SELECT 1 FROM turns WHERE thread_id = threads.id AND status = ?)`,
+    )
+    const reconciled = reconcileTerminalActiveThreads.run(
+      JSON.stringify({ type: 'idle' }),
+      completedAt,
+      'inProgress',
+    ) as { changes?: number }
+    recoveredCount += Number(reconciled.changes ?? 0)
     return recoveredCount
   }
 
@@ -507,6 +524,7 @@ export class SessionStore {
     itemsJson: string,
     message: string,
     terminalizeActivity = true,
+    stripCompletedActivity = false,
   ): string {
     let parsed: unknown
     try {
@@ -516,45 +534,59 @@ export class SessionStore {
     }
     if (!Array.isArray(parsed)) return '[]'
 
-    const items = parsed.map((raw) => {
-      if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return raw
-      const item = raw as Record<string, unknown>
-      if (
-        terminalizeActivity &&
-        item.type === 'subAgentActivity' &&
-        (item.kind === 'started' || item.kind === 'interacted')
-      ) {
-        return { ...item, kind: 'interrupted' }
-      }
-      if (item.type === 'collabAgentToolCall') {
-        const agentsStates = item.agentsStates
-        const nextStates =
-          agentsStates && typeof agentsStates === 'object' && !Array.isArray(agentsStates)
-            ? Object.fromEntries(
-                Object.entries(agentsStates as Record<string, unknown>).map(
-                  ([threadId, rawState]) => {
-                    if (rawState == null || typeof rawState !== 'object' || Array.isArray(rawState))
-                      return [threadId, rawState]
-                    const state = rawState as Record<string, unknown>
-                    if (state.status !== 'pendingInit' && state.status !== 'running')
-                      return [threadId, state]
-                    return [
-                      threadId,
-                      { ...state, status: 'errored', message: state.message ?? message },
-                    ]
-                  },
-                ),
-              )
-            : agentsStates
-        return {
-          ...item,
-          ...(item.status === 'inProgress' ? { status: 'failed' } : {}),
-          agentsStates: nextStates,
+    const items = parsed
+      .map((raw) => {
+        if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return raw
+        const item = raw as Record<string, unknown>
+        if (stripCompletedActivity && item.type === 'subAgentActivity') return null
+        if (
+          terminalizeActivity &&
+          item.type === 'subAgentActivity' &&
+          (item.kind === 'started' || item.kind === 'interacted')
+        ) {
+          return { ...item, kind: 'interrupted' }
         }
-      }
-      if (item.status === 'inProgress') return { ...item, status: 'failed' }
-      return item
-    })
+        // Older adapter builds persisted the newer `completed` activity kind,
+        // which Codex cc 26.x cannot deserialize. `interrupted` is the legacy
+        // terminal marker understood by the App reducer and prevents a cold
+        // open from reviving the child as working.
+        if (item.type === 'subAgentActivity' && item.kind === 'completed') {
+          return { ...item, kind: 'interrupted' }
+        }
+        if (item.type === 'collabAgentToolCall') {
+          const agentsStates = item.agentsStates
+          const nextStates =
+            agentsStates && typeof agentsStates === 'object' && !Array.isArray(agentsStates)
+              ? Object.fromEntries(
+                  Object.entries(agentsStates as Record<string, unknown>).map(
+                    ([threadId, rawState]) => {
+                      if (
+                        rawState == null ||
+                        typeof rawState !== 'object' ||
+                        Array.isArray(rawState)
+                      )
+                        return [threadId, rawState]
+                      const state = rawState as Record<string, unknown>
+                      if (state.status !== 'pendingInit' && state.status !== 'running')
+                        return [threadId, state]
+                      return [
+                        threadId,
+                        { ...state, status: 'errored', message: state.message ?? message },
+                      ]
+                    },
+                  ),
+                )
+              : agentsStates
+          return {
+            ...item,
+            ...(item.status === 'inProgress' ? { status: 'failed' } : {}),
+            agentsStates: nextStates,
+          }
+        }
+        if (item.status === 'inProgress') return { ...item, status: 'failed' }
+        return item
+      })
+      .filter((item) => item != null)
     return JSON.stringify(items)
   }
 

--- a/src/store.mts
+++ b/src/store.mts
@@ -183,30 +183,87 @@ export class SessionStore {
       cursor?: string | null
       cwd?: string | string[] | null
       includeEphemeral?: boolean
+      parentThreadId?: string | null
+      ancestorThreadId?: string | null
+      sourceKinds?: string[]
+      sortKey?: 'created_at' | 'updated_at'
+      sortDirection?: 'asc' | 'desc'
     } = {},
   ): ThreadRecord[] {
     const limit = Math.max(1, Math.min(Number(options.limit ?? 50), 200))
     const archived = options.archived === true ? 1 : 0
-    const cursor = options.cursor ? Number(options.cursor) : Number.MAX_SAFE_INTEGER
+    const sortKey = options.sortKey === 'created_at' ? 'created_at' : 'updated_at'
+    const sortDirection = options.sortDirection === 'asc' ? 'ASC' : 'DESC'
+    const cursor = options.cursor
+      ? Number(options.cursor)
+      : sortDirection === 'ASC'
+        ? -1
+        : Number.MAX_SAFE_INTEGER
+    const where = ['t.archived = ?', `t.${sortKey} ${sortDirection === 'ASC' ? '>' : '<'} ?`]
+    const args: unknown[] = [archived, cursor]
+    const parentThreadId = options.parentThreadId ?? null
+    const ancestorThreadId = options.ancestorThreadId ?? null
+    const sourceKinds = options.sourceKinds ?? []
+
+    if (parentThreadId != null) {
+      where.push('t.forked_from_id = ?')
+      args.push(parentThreadId)
+    }
+    if (ancestorThreadId != null) {
+      where.push('t.id IN (SELECT id FROM descendants)')
+    }
+
+    if (sourceKinds.length > 0) {
+      const predicates = sourceKinds.flatMap((kind) => {
+        switch (kind) {
+          case 'subAgentThreadSpawn':
+            return ["(t.thread_source = 'subagent' AND t.forked_from_id IS NOT NULL)"]
+          case 'user':
+            return ["t.thread_source = 'user'"]
+          case 'memoryConsolidation':
+            return ["t.thread_source = 'memory_consolidation'"]
+          case 'appServer':
+          case 'cli':
+          case 'exec':
+          case 'vscode':
+          case 'unknown':
+            return [`t.source = '${kind}'`]
+          default:
+            return []
+        }
+      })
+      where.push(predicates.length > 0 ? `(${predicates.join(' OR ')})` : '1 = 0')
+    }
+
     // Ephemeral threads (Codex App's internal title generators, subagent
     // children, memory-consolidation runs) shouldn't appear in the user's
-    // session list. Callers can opt back in for diagnostic flows.
-    const ephemeralFilter = options.includeEphemeral ? '' : ' AND ephemeral = 0'
+    // session list. Topology queries are the exception: Codex App asks for
+    // subagent descendants without sending our legacy includeEphemeral flag.
+    const topologyQuery =
+      parentThreadId != null || ancestorThreadId != null || sourceKinds.length > 0
+    if (!options.includeEphemeral && !topologyQuery) where.push('t.ephemeral = 0')
+
     const cwdList = Array.isArray(options.cwd) ? options.cwd : options.cwd ? [options.cwd] : []
     if (cwdList.length > 0) {
       const placeholders = cwdList.map(() => '?').join(',')
-      const rows = this.db
-        .prepare(
-          `SELECT * FROM threads WHERE archived = ? AND updated_at < ? AND cwd IN (${placeholders})${ephemeralFilter} ORDER BY updated_at DESC LIMIT ?`,
-        )
-        .all(archived, cursor, ...cwdList, limit)
-      return rows.map((row: unknown) => this.rowToThread(row))
+      where.push(`t.cwd IN (${placeholders})`)
+      args.push(...cwdList)
     }
+
+    const cte =
+      ancestorThreadId == null
+        ? ''
+        : `WITH RECURSIVE descendants(id) AS (
+            SELECT id FROM threads WHERE forked_from_id = ?
+            UNION
+            SELECT child.id FROM threads child JOIN descendants parent ON child.forked_from_id = parent.id
+          )`
+    const queryArgs = ancestorThreadId == null ? args : [ancestorThreadId, ...args]
     const rows = this.db
       .prepare(
-        `SELECT * FROM threads WHERE archived = ? AND updated_at < ?${ephemeralFilter} ORDER BY updated_at DESC LIMIT ?`,
+        `${cte} SELECT t.* FROM threads t WHERE ${where.join(' AND ')} ORDER BY t.${sortKey} ${sortDirection}, t.id ${sortDirection} LIMIT ?`,
       )
-      .all(archived, cursor, limit)
+      .all(...queryArgs, limit)
     return rows.map((row: unknown) => this.rowToThread(row))
   }
 

--- a/src/types.mts
+++ b/src/types.mts
@@ -238,6 +238,16 @@ export type ThreadItem =
         }
       >
     }
+  // Canonical MultiAgent V2 display/liveness item. Codex App discovers the
+  // child from `started` and clears its working state from `completed` or
+  // `interrupted`; collabAgentToolCall remains the structured tool timeline.
+  | {
+      type: 'subAgentActivity'
+      id: string
+      kind: 'started' | 'interacted' | 'interrupted' | 'completed'
+      agentThreadId: string
+      agentPath: string
+    }
   // Codex's native dynamic tool call item — used to surface AskUserQuestion as
   // a structured choice card the App renders inline (paired with the
   // item/tool/requestUserInput reverse RPC). The contentItems array carries

--- a/src/types.mts
+++ b/src/types.mts
@@ -79,6 +79,11 @@ export interface ThreadRecord {
   // permission_mode and the can_use_tool callback.
   approvalPolicy: string | null
   sandboxMode: string | null
+  // Newer Codex clients send a built-in or custom permission profile id
+  // (for example `:danger-full-access`) instead of a legacy sandbox string.
+  // Keep it alongside the normalized policies so the profile survives resume
+  // and the settings UI can round-trip its selection.
+  permissionProfileId?: string | null
   // Codex App marks transient title-generation / consolidation threads as
   // ephemeral — these should not appear in the user-facing thread list.
   ephemeral: boolean

--- a/src/workflow-command.mts
+++ b/src/workflow-command.mts
@@ -1,0 +1,22 @@
+const WORKFLOWS_COMMAND = /^\s*\/workflows(?=$|\s)([\s\S]*)$/
+
+export type WorkflowCommand =
+  | { readonly type: 'list' }
+  | { readonly type: 'run'; readonly prompt: string }
+
+export function parseWorkflowCommand(prompt: string): WorkflowCommand | null {
+  const match = prompt.match(WORKFLOWS_COMMAND)
+  if (!match) return null
+  const task = (match[1] ?? '').trim()
+  return task ? { type: 'run', prompt: task } : { type: 'list' }
+}
+
+export function workflowRuntimePrompt(prompt: string): string {
+  const command = parseWorkflowCommand(prompt)
+  if (command?.type !== 'run') return prompt
+  return [
+    `ultracode: ${command.prompt}`,
+    '',
+    'Keep the launched workflow attached to this turn: wait for every workflow task to finish before returning the final response.',
+  ].join('\n')
+}

--- a/src/workflow-subagents.mts
+++ b/src/workflow-subagents.mts
@@ -57,6 +57,13 @@ export function parseWorkflowLaunchInfo(
 ): WorkflowLaunchInfo | null {
   const launch = recordOrNull(value)
   if (!launch) return null
+  if (launch.taskType == null) launch.taskType = launch.task_type
+  if (launch.taskType == null) launch.taskType = 'local_workflow'
+  if (launch.taskType === 'workflow') launch.taskType = 'local_workflow'
+  if (launch.taskId == null) launch.taskId = launch.task_id
+  if (launch.runId == null) launch.runId = launch.run_id
+  if (launch.transcriptDir == null) launch.transcriptDir = launch.transcript_dir
+  if (launch.workflowName == null) launch.workflowName = launch.workflow_name
   if (String(launch.status ?? '') !== 'async_launched') return null
   if (String(launch.taskType ?? '') !== 'local_workflow') return null
 
@@ -80,7 +87,7 @@ export function parseWorkflowLaunchInfo(
     runId,
     transcriptDir: normalizedTranscriptDir,
     transcriptRoot,
-    workflowName: stringValue(launch.workflowName),
+    workflowName: stringValue(launch.workflowName ?? launch.workflow_name),
     summary: stringValue(launch.summary),
   }
 }

--- a/src/workflow-subagents.mts
+++ b/src/workflow-subagents.mts
@@ -29,6 +29,7 @@ interface WorkflowJournalMonitorOptions {
   pollIntervalMs?: number
   onStarted: (agent: WorkflowJournalAgentStart) => Promise<void>
   onResult: (agent: WorkflowJournalAgentResult) => Promise<void>
+  onError?: (error: Error) => Promise<void> | void
 }
 
 interface WorkflowJournalEntry {
@@ -89,6 +90,7 @@ export class WorkflowJournalMonitor {
   private readonly pollIntervalMs: number
   private readonly onStarted: WorkflowJournalMonitorOptions['onStarted']
   private readonly onResult: WorkflowJournalMonitorOptions['onResult']
+  private readonly onError: WorkflowJournalMonitorOptions['onError']
   private readonly startedAgentIds = new Set<string>()
   private readonly completedAgentIds = new Set<string>()
   private timer: NodeJS.Timeout | null = null
@@ -103,6 +105,7 @@ export class WorkflowJournalMonitor {
     this.pollIntervalMs = Math.max(10, options.pollIntervalMs ?? 100)
     this.onStarted = options.onStarted
     this.onResult = options.onResult
+    this.onError = options.onError
   }
 
   start(): void {
@@ -119,8 +122,17 @@ export class WorkflowJournalMonitor {
     if (this.pollPromise) return this.pollPromise
     const generation = this.generation
     this.pollPromise = this.pollOnce(generation)
-      .catch((error: unknown) => {
+      .catch(async (error: unknown) => {
         this.fail(error)
+        const failure = this.failure
+        if (failure && this.onError) {
+          // Monitoring runs from an unref'd interval. Never let a failure in
+          // the cleanup callback become an unhandled rejection that leaves the
+          // parent runtime promise pending as well.
+          try {
+            await this.onError(failure)
+          } catch {}
+        }
       })
       .finally(() => {
         this.pollPromise = null

--- a/src/workflow-subagents.mts
+++ b/src/workflow-subagents.mts
@@ -1,0 +1,502 @@
+import { constants } from 'node:fs'
+import { lstat, open, realpath } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path'
+
+export interface WorkflowLaunchInfo {
+  taskId: string
+  runId: string
+  transcriptDir: string
+  transcriptRoot: string
+  workflowName: string
+  summary: string
+}
+
+export interface WorkflowJournalAgentStart {
+  agentId: string
+  prompt: string
+  description: string
+}
+
+export interface WorkflowJournalAgentResult {
+  agentId: string
+  content: string
+  isError: boolean
+}
+
+interface WorkflowJournalMonitorOptions {
+  launch: WorkflowLaunchInfo
+  pollIntervalMs?: number
+  onStarted: (agent: WorkflowJournalAgentStart) => Promise<void>
+  onResult: (agent: WorkflowJournalAgentResult) => Promise<void>
+}
+
+interface WorkflowJournalEntry {
+  type: 'started' | 'result'
+  agentId: string
+  result?: unknown
+}
+
+const MAX_WORKFLOW_JOURNAL_BYTES = 8 * 1024 * 1024
+const MAX_WORKFLOW_AGENT_TRANSCRIPT_BYTES = 4 * 1024 * 1024
+const WORKFLOW_DRAIN_SETTLE_MS = 500
+
+export function defaultWorkflowTranscriptRoots(
+  env: NodeJS.ProcessEnv = process.env,
+  cwd = process.cwd(),
+): string[] {
+  const configuredRoot = stringValue(env.CLAUDE_CONFIG_DIR)
+  const home = stringValue(env.HOME) || homedir()
+  return [resolve(cwd, configuredRoot || join(home, '.claude'))]
+}
+
+export function parseWorkflowLaunchInfo(
+  value: unknown,
+  transcriptRoots: string[] = defaultWorkflowTranscriptRoots(),
+): WorkflowLaunchInfo | null {
+  const launch = recordOrNull(value)
+  if (!launch) return null
+  if (String(launch.status ?? '') !== 'async_launched') return null
+  if (String(launch.taskType ?? '') !== 'local_workflow') return null
+
+  const taskId = stringValue(launch.taskId)
+  const runId = stringValue(launch.runId)
+  const transcriptDir = stringValue(launch.transcriptDir)
+  const normalizedTranscriptDir = normalize(transcriptDir)
+  const transcriptRoot = trustedTranscriptRoot(normalizedTranscriptDir, transcriptRoots)
+  if (
+    !taskId ||
+    !runId ||
+    !transcriptDir ||
+    !isWorkflowTranscriptDir(normalizedTranscriptDir, runId) ||
+    !transcriptRoot
+  ) {
+    return null
+  }
+
+  return {
+    taskId,
+    runId,
+    transcriptDir: normalizedTranscriptDir,
+    transcriptRoot,
+    workflowName: stringValue(launch.workflowName),
+    summary: stringValue(launch.summary),
+  }
+}
+
+export class WorkflowJournalMonitor {
+  private readonly launch: WorkflowLaunchInfo
+  private readonly pollIntervalMs: number
+  private readonly onStarted: WorkflowJournalMonitorOptions['onStarted']
+  private readonly onResult: WorkflowJournalMonitorOptions['onResult']
+  private readonly startedAgentIds = new Set<string>()
+  private readonly completedAgentIds = new Set<string>()
+  private timer: NodeJS.Timeout | null = null
+  private pollPromise: Promise<void> | null = null
+  private verifiedTranscriptDir: string | null = null
+  private failure: Error | null = null
+  private generation = 0
+  private stopped = false
+
+  constructor(options: WorkflowJournalMonitorOptions) {
+    this.launch = options.launch
+    this.pollIntervalMs = Math.max(10, options.pollIntervalMs ?? 100)
+    this.onStarted = options.onStarted
+    this.onResult = options.onResult
+  }
+
+  start(): void {
+    if (this.stopped || this.timer) return
+    this.timer = setInterval(() => {
+      void this.flush()
+    }, this.pollIntervalMs)
+    this.timer.unref()
+    void this.flush()
+  }
+
+  async flush(): Promise<void> {
+    if (this.stopped || this.failure) return
+    if (this.pollPromise) return this.pollPromise
+    const generation = this.generation
+    this.pollPromise = this.pollOnce(generation)
+      .catch((error: unknown) => {
+        this.fail(error)
+      })
+      .finally(() => {
+        this.pollPromise = null
+      })
+    return this.pollPromise
+  }
+
+  async drain(timeoutMs = 500): Promise<void> {
+    const deadline = Date.now() + Math.max(0, timeoutMs)
+    let stableSince = Date.now()
+    let lastStarted = this.startedAgentIds.size
+    let lastCompleted = this.completedAgentIds.size
+    while (Date.now() <= deadline) {
+      const remaining = Math.max(0, deadline - Date.now())
+      if (!(await settlesWithin(this.flush(), remaining))) return
+      if (this.stopped || this.failure) return
+      const now = Date.now()
+      const started = this.startedAgentIds.size
+      const completed = this.completedAgentIds.size
+      if (started !== lastStarted || completed !== lastCompleted) {
+        lastStarted = started
+        lastCompleted = completed
+        stableSince = now
+      }
+      if (started > 0 && completed >= started && now - stableSince >= WORKFLOW_DRAIN_SETTLE_MS) {
+        return
+      }
+      if (now >= deadline) return
+      await delay(Math.min(this.pollIntervalMs, Math.max(1, deadline - now)))
+    }
+  }
+
+  async stop(timeoutMs = 500): Promise<void> {
+    if (this.timer) clearInterval(this.timer)
+    this.timer = null
+    this.stopped = true
+    this.generation += 1
+    if (this.pollPromise) {
+      await settlesWithin(this.pollPromise, Math.max(0, timeoutMs))
+    }
+  }
+
+  get startedCount(): number {
+    return this.startedAgentIds.size
+  }
+
+  activeAgentIds(): string[] {
+    return [...this.startedAgentIds].filter((agentId) => !this.completedAgentIds.has(agentId))
+  }
+
+  private async pollOnce(generation: number): Promise<void> {
+    if (!this.isCurrent(generation)) return
+    const transcriptDir = await this.resolveTranscriptDir()
+    if (!transcriptDir || !this.isCurrent(generation)) return
+    const entries = await readJournalEntries(join(transcriptDir, 'journal.jsonl'), transcriptDir)
+    if (!this.isCurrent(generation)) return
+    for (const entry of entries) {
+      if (!this.isCurrent(generation)) return
+      const started = await this.ensureStarted(transcriptDir, entry.agentId, generation)
+      if (!this.isCurrent(generation)) return
+      if (!started) continue
+      if (entry.type !== 'result' || this.completedAgentIds.has(entry.agentId)) continue
+      const result = await workflowAgentResult(transcriptDir, entry.agentId, entry.result)
+      if (!result || !this.isCurrent(generation)) continue
+      await this.onResult(result)
+      if (!this.isCurrent(generation)) return
+      this.completedAgentIds.add(entry.agentId)
+    }
+  }
+
+  private async ensureStarted(
+    transcriptDir: string,
+    agentId: string,
+    generation: number,
+  ): Promise<boolean> {
+    if (this.startedAgentIds.has(agentId)) return true
+    const prompt = await readAgentPrompt(transcriptDir, agentId)
+    if (!prompt || !this.isCurrent(generation)) return false
+    await this.onStarted({
+      agentId,
+      prompt,
+      description: workflowAgentDescription(prompt, agentId),
+    })
+    if (!this.isCurrent(generation)) return false
+    this.startedAgentIds.add(agentId)
+    return true
+  }
+
+  private async resolveTranscriptDir(): Promise<string | null> {
+    if (this.verifiedTranscriptDir) return this.verifiedTranscriptDir
+    let transcriptRoot: string
+    let transcriptDir: string
+    try {
+      ;[transcriptRoot, transcriptDir] = await Promise.all([
+        realpath(this.launch.transcriptRoot),
+        realpath(this.launch.transcriptDir),
+      ])
+    } catch (error) {
+      if (isMissingFile(error)) return null
+      throw error
+    }
+    if (
+      !isPathInside(transcriptRoot, transcriptDir) ||
+      !isWorkflowTranscriptDir(transcriptDir, this.launch.runId)
+    ) {
+      throw new Error('Workflow transcript directory is outside the trusted Claude config root')
+    }
+    this.verifiedTranscriptDir = transcriptDir
+    return transcriptDir
+  }
+
+  private fail(error: unknown): void {
+    this.failure = error instanceof Error ? error : new Error(String(error))
+    if (this.timer) clearInterval(this.timer)
+    this.timer = null
+    this.stopped = true
+    this.generation += 1
+  }
+
+  private isCurrent(generation: number): boolean {
+    return !this.stopped && !this.failure && this.generation === generation
+  }
+}
+
+function isWorkflowTranscriptDir(path: string, runId: string): boolean {
+  if (!isAbsolute(path) || basename(normalize(path)) !== runId) return false
+  const parts = normalize(path).split(sep).filter(Boolean)
+  const workflowIndex = parts.lastIndexOf('workflows')
+  return (
+    workflowIndex > 0 &&
+    workflowIndex === parts.length - 2 &&
+    parts[workflowIndex - 1] === 'subagents'
+  )
+}
+
+function trustedTranscriptRoot(path: string, roots: string[]): string | null {
+  if (!isAbsolute(path)) return null
+  const normalizedRoots = roots
+    .map((root) => stringValue(root))
+    .filter(Boolean)
+    .map((root) => resolve(root))
+    .sort((left, right) => right.length - left.length)
+  return normalizedRoots.find((root) => isPathInside(root, path)) ?? null
+}
+
+function isPathInside(root: string, path: string): boolean {
+  const child = relative(root, path)
+  return child !== '' && child !== '..' && !child.startsWith(`..${sep}`) && !isAbsolute(child)
+}
+
+async function readJournalEntries(
+  path: string,
+  transcriptDir: string,
+): Promise<WorkflowJournalEntry[]> {
+  const text = await readRegularTextFile(path, transcriptDir, MAX_WORKFLOW_JOURNAL_BYTES)
+  if (text === null) return []
+
+  const entries: WorkflowJournalEntry[] = []
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue
+    }
+    const entry = recordOrNull(parsed)
+    if (!entry) continue
+    const type = String(entry.type ?? '')
+    const agentId = stringValue(entry.agentId)
+    if ((type !== 'started' && type !== 'result') || !isWorkflowAgentId(agentId)) continue
+    entries.push({
+      type,
+      agentId,
+      ...(type === 'result' ? { result: entry.result } : {}),
+    })
+  }
+  return entries
+}
+
+async function readAgentPrompt(transcriptDir: string, agentId: string): Promise<string | null> {
+  const text = await readRegularTextFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    transcriptDir,
+    MAX_WORKFLOW_AGENT_TRANSCRIPT_BYTES,
+  )
+  if (text === null) return null
+
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue
+    }
+    const record = recordOrNull(parsed)
+    const message = recordOrNull(record?.message)
+    if (message?.role !== 'user') continue
+    const prompt = messageText(message.content)
+    if (prompt) return prompt
+  }
+  return null
+}
+
+async function readRegularTextFile(
+  path: string,
+  transcriptDir: string,
+  maxBytes: number,
+): Promise<string | null> {
+  let canonicalBefore: string
+  try {
+    canonicalBefore = await realpath(path)
+  } catch (error) {
+    if (isMissingFile(error)) return null
+    throw error
+  }
+  if (!isPathInside(transcriptDir, canonicalBefore)) {
+    throw new Error('Workflow transcript file is outside the verified transcript directory')
+  }
+
+  let handle: Awaited<ReturnType<typeof open>>
+  try {
+    handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW)
+  } catch (error) {
+    if (isMissingFile(error)) return null
+    throw error
+  }
+
+  try {
+    const openedEntry = await handle.stat()
+    if (!openedEntry.isFile()) {
+      throw new Error('Workflow transcript entry is not a regular file')
+    }
+    if (openedEntry.size > maxBytes) {
+      throw new Error('Workflow transcript entry exceeds the configured size limit')
+    }
+    const [canonicalAfter, currentEntry] = await Promise.all([realpath(path), lstat(path)])
+    if (
+      canonicalAfter !== canonicalBefore ||
+      !isPathInside(transcriptDir, canonicalAfter) ||
+      !currentEntry.isFile() ||
+      currentEntry.isSymbolicLink() ||
+      currentEntry.dev !== openedEntry.dev ||
+      currentEntry.ino !== openedEntry.ino
+    ) {
+      throw new Error('Workflow transcript entry changed during validation')
+    }
+    return await handle.readFile('utf8')
+  } catch (error) {
+    if (isMissingFile(error)) return null
+    throw error
+  } finally {
+    await handle.close()
+  }
+}
+
+async function workflowAgentResult(
+  transcriptDir: string,
+  agentId: string,
+  result: unknown,
+): Promise<WorkflowJournalAgentResult | null> {
+  const resultRecord = recordOrNull(result)
+  const status = String(resultRecord?.status ?? '')
+    .trim()
+    .toLowerCase()
+  const isError =
+    Boolean(resultRecord?.error) ||
+    status === 'error' ||
+    status === 'errored' ||
+    status === 'failed' ||
+    status === 'failure'
+  const body = resultText(result) || (await readAgentResult(transcriptDir, agentId))
+  if (!body) return null
+  return {
+    agentId,
+    content: `${body}\nagentId: ${agentId}`,
+    isError,
+  }
+}
+
+async function readAgentResult(transcriptDir: string, agentId: string): Promise<string | null> {
+  const text = await readRegularTextFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    transcriptDir,
+    MAX_WORKFLOW_AGENT_TRANSCRIPT_BYTES,
+  )
+  if (text === null) return null
+
+  let finalText = ''
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue
+    }
+    const record = recordOrNull(parsed)
+    const message = recordOrNull(record?.message)
+    if (message?.role !== 'assistant') continue
+    const content = messageText(message.content)
+    if (content) finalText = content
+  }
+  return finalText || null
+}
+
+function workflowAgentDescription(prompt: string, agentId: string): string {
+  const firstLine = prompt
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean)
+  return (firstLine || `Workflow agent ${agentId}`).slice(0, 120)
+}
+
+function resultText(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (value == null) return ''
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function messageText(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (!Array.isArray(value)) return ''
+  return value
+    .map((block) => {
+      const record = recordOrNull(block)
+      return record?.type === 'text' ? stringValue(record.text) : ''
+    })
+    .filter(Boolean)
+    .join('\n')
+    .trim()
+}
+
+function isWorkflowAgentId(value: string): boolean {
+  return /^[0-9a-f]{8,32}$/i.test(value)
+}
+
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isMissingFile(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    ((error as NodeJS.ErrnoException).code === 'ENOENT' ||
+      (error as NodeJS.ErrnoException).code === 'ENOTDIR')
+  )
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function settlesWithin(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
+  if (timeoutMs <= 0) return false
+  let timer: NodeJS.Timeout | null = null
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<boolean>((resolveTimeout) => {
+        timer = setTimeout(() => resolveTimeout(false), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -11,6 +11,7 @@ import { Duplex } from 'node:stream'
 import test from 'node:test'
 import WebSocket from 'ws'
 import type { ProviderLoopConfigProjectionResult } from '../src/provider-loop-config.mjs'
+import { SessionStore } from '../src/store.mjs'
 
 const adapter = resolve('dist/src/adapter.mjs')
 const shim = resolve('scripts/codex-shim')
@@ -1511,6 +1512,114 @@ test('stdio app-server recovers stale in-progress turns after process restart', 
     assert.match(recoveredTurn.error.message, /server restarted before completing turn/)
   } finally {
     proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
+test('startup recovery terminalizes persisted in-progress item liveness', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const store = new SessionStore(join(home, 'state.sqlite'))
+  const threadId = randomUUID()
+  const childThreadId = randomUUID()
+  const turnId = randomUUID()
+  try {
+    store.upsertThread({
+      id: threadId,
+      sessionId: threadId,
+      forkedFromId: null,
+      preview: 'stale item recovery',
+      name: null,
+      archived: false,
+      cwd: process.cwd(),
+      model: 'sonnet',
+      reasoningEffort: null,
+      modelProvider: 'claude-code',
+      claudeSessionId: null,
+      source: 'appServer',
+      createdAt: Math.floor(Date.now() / 1000) - 2,
+      updatedAt: Math.floor(Date.now() / 1000) - 2,
+      status: { type: 'active', activeFlags: [] },
+      approvalPolicy: 'on-request',
+      sandboxMode: 'workspace-write',
+      ephemeral: false,
+      threadSource: 'user',
+      agentRole: null,
+      agentNickname: null,
+      baseInstructions: null,
+      developerInstructions: null,
+      personality: null,
+      runtimeBackend: 'claude',
+      codexSessionId: null,
+    })
+    store.upsertTurn({
+      id: turnId,
+      threadId,
+      status: 'inProgress',
+      startedAt: Math.floor(Date.now() / 1000) - 2,
+      completedAt: null,
+      durationMs: null,
+      items: [
+        {
+          type: 'userMessage',
+          id: randomUUID(),
+          content: [{ type: 'text', text: 'stale item recovery', text_elements: [] }],
+        },
+        {
+          type: 'subAgentActivity',
+          id: randomUUID(),
+          kind: 'started',
+          agentThreadId: childThreadId,
+          agentPath: '/root/agent-stale',
+        },
+        {
+          type: 'collabAgentToolCall',
+          id: randomUUID(),
+          tool: 'wait',
+          status: 'inProgress',
+          senderThreadId: threadId,
+          receiverThreadIds: [childThreadId],
+          prompt: null,
+          model: null,
+          reasoningEffort: null,
+          agentsStates: { [childThreadId]: { status: 'running', message: null } },
+        },
+        {
+          type: 'commandExecution',
+          id: randomUUID(),
+          command: 'echo stale',
+          cwd: process.cwd(),
+          processId: null,
+          source: 'shell',
+          status: 'inProgress',
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      ],
+      diff: '',
+      error: null,
+    })
+
+    assert.equal(store.recoverStaleInProgressTurns(), 1)
+    const recovered = store.getTurn(turnId)
+    assert.ok(recovered)
+    assert.equal(recovered.status, 'interrupted')
+    assert.equal(store.getThread(threadId)?.status.type, 'idle')
+    const activity = recovered.items.find((item) => item.type === 'subAgentActivity')
+    assert.equal(activity?.type === 'subAgentActivity' ? activity.kind : null, 'interrupted')
+    const wait = recovered.items.find(
+      (item) => item.type === 'collabAgentToolCall' && item.tool === 'wait',
+    )
+    assert.equal(wait?.type === 'collabAgentToolCall' ? wait.status : null, 'failed')
+    assert.equal(
+      wait?.type === 'collabAgentToolCall' ? wait.agentsStates[childThreadId]?.status : null,
+      'errored',
+    )
+    const command = recovered.items.find((item) => item.type === 'commandExecution')
+    assert.equal(command?.type === 'commandExecution' ? command.status : null, 'failed')
+  } finally {
+    store.close()
     await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
   }
 })

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -2980,7 +2980,9 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
           json({
             id: 50,
             method: 'thread/read',
-            params: { threadId: message.params.threadId, includeTurns: true },
+            // The bundled Codex cc panel uses includeTurns:false while it
+            // opens a child. The adapter must still hydrate this subagent.
+            params: { threadId: message.params.threadId, includeTurns: false },
           }),
         )
       }
@@ -3377,12 +3379,14 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
         json({
           id: 3,
           method: 'thread/read',
-          params: { threadId: childThreadId, includeTurns: true },
+          // Cold-open follows the same metadata-only request as Codex cc.
+          params: { threadId: childThreadId, includeTurns: false },
         }),
       )
       const coldChild = (await restartedReader.nextResponse(3)).result.thread
       assert.equal(coldChild.turns.length, 1)
       assert.equal(coldChild.turns[0].status, 'completed')
+      assert.equal(coldChild.turns[0].itemsView, 'full')
       assert.equal(
         coldChild.turns[0].items.find((item: any) => item.type === 'userMessage').content[0].text,
         'investigate',
@@ -3390,6 +3394,20 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
       assert.match(
         coldChild.turns[0].items.find((item: any) => item.type === 'agentMessage').text,
         /subagent final summary/,
+      )
+
+      restarted.stdin.write(
+        json({
+          id: 4,
+          method: 'thread/read',
+          params: { threadId, includeTurns: false },
+        }),
+      )
+      const metadataOnlyParent = (await restartedReader.nextResponse(4)).result.thread
+      assert.equal(
+        metadataOnlyParent.turns.length,
+        0,
+        'ordinary thread/read includeTurns:false must remain metadata-only',
       )
     } finally {
       restarted.kill()
@@ -3483,7 +3501,27 @@ test('Codex cc 26.818 settles subagents without the unsupported completed activi
     assert.equal(
       sawCloseAgent,
       true,
-      "legacy Codex cc needs closeAgent to clear the child spinner when completed activity is unsupported",
+      'legacy Codex cc needs closeAgent to clear the child spinner when completed activity is unsupported',
+    )
+
+    proc.stdin.write(
+      json({
+        id: 3,
+        method: 'thread/read',
+        params: { threadId: childThreadId, includeTurns: false },
+      }),
+    )
+    const legacyChild = (await reader.nextResponse(3)).result.thread
+    assert.equal(legacyChild.turns.length, 1)
+    assert.equal(legacyChild.turns[0].status, 'completed')
+    assert.equal(legacyChild.turns[0].itemsView, 'full')
+    assert.equal(
+      legacyChild.turns[0].items.find((item: any) => item.type === 'userMessage').content[0].text,
+      'investigate',
+    )
+    assert.match(
+      legacyChild.turns[0].items.find((item: any) => item.type === 'agentMessage').text,
+      /subagent final summary/,
     )
   } finally {
     proc.kill()
@@ -3541,7 +3579,11 @@ test('subagent without a terminal result emits interrupted activity and failed w
 
     assert.ok(childThreadId)
     assert.equal(waitStatus, 'failed')
-    assert.equal(sawClose, false)
+    assert.equal(
+      sawClose,
+      true,
+      'legacy Codex cc needs closeAgent to clear an orphaned child spinner',
+    )
     assert.deepEqual(activityKinds, ['interrupted'])
     assert.ok(childTurnCompleted)
     assert.equal(childTurnCompleted.status, 'failed')

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -246,12 +246,10 @@ test('run registry records thread and turn lifecycle without raw prompt or respo
   }
 })
 
-test('turn lifecycle envelopes carry empty notLoaded items like the real app-server', async () => {
-  // The real codex app-server ships `items: [], itemsView: "notLoaded"` in the
-  // turn/start response and the turn/started + turn/completed notifications; the
-  // timeline is driven by the item/* event stream. See codex-rs
-  // bespoke_event_handling.rs (turn started clears items; turn completed builds
-  // items: vec![]) and turn_processor.rs (TurnStartResponse turn is empty).
+test('primary turn lifecycle keeps lightweight notLoaded envelopes', async () => {
+  // turn/start and turn/started are metadata-only. Primary-thread completion
+  // remains item-stream driven here; subagent completion is covered separately
+  // because its terminal envelope must carry the final response for review UI.
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -2604,6 +2602,23 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
     const childThreadId = spawnEnd.receiverThreadIds[0]!
     assert.ok(childThreadStarted, 'subagent must emit child thread/started for live navigation')
     assert.equal(childThreadStarted.id, childThreadId)
+    assert.equal(
+      childThreadStarted.parentThreadId,
+      threadId,
+      'subagent thread metadata must identify its parent thread',
+    )
+    assert.equal(childThreadStarted.recencyAt, childThreadStarted.updatedAt)
+    assert.deepEqual(childThreadStarted.source, {
+      subAgent: {
+        thread_spawn: {
+          parent_thread_id: threadId,
+          depth: 1,
+          agent_path: null,
+          agent_nickname: childThreadStarted.agentNickname,
+          agent_role: 'general-purpose',
+        },
+      },
+    })
     assert.ok(childTurnStarted, 'subagent must emit child turn/started before its result')
     assert.equal(childTurnStarted.status, 'inProgress')
     assert.equal(childTurnStarted.itemsView, 'notLoaded')
@@ -2632,8 +2647,15 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
     )
     assert.equal(childTurnCompleted.id, childTurnStarted.id)
     assert.equal(childTurnCompleted.status, 'completed')
-    assert.equal(childTurnCompleted.itemsView, 'notLoaded')
-    assert.deepEqual(childTurnCompleted.items, [])
+    assert.equal(
+      childTurnCompleted.itemsView,
+      'summary',
+      'completed subagent turns must carry their final response in the terminal envelope',
+    )
+    assert.equal(childTurnCompleted.items.length, 1)
+    assert.equal(childTurnCompleted.items[0].type, 'agentMessage')
+    assert.equal(childTurnCompleted.items[0].id, childAgentCompleted.id)
+    assert.match(childTurnCompleted.items[0].text, /subagent final summary/)
     // After spawnAgent ends the subagent is now running; only wait/closeAgent
     // ends report the agent as completed.
     assert.equal(spawnEnd.agentsStates[childThreadId]!.status, 'running')
@@ -2767,6 +2789,7 @@ test('subagent without a terminal result is closed as failed', async () => {
     let childThreadId = ''
     let waitStatus = ''
     let closeStatus = ''
+    let childTurnCompleted: any = null
     for (let i = 0; i < 200; i += 1) {
       const message = await reader.next()
       if (message.method === 'item/completed') {
@@ -2777,12 +2800,18 @@ test('subagent without a terminal result is closed as failed', async () => {
         if (item.type === 'collabAgentToolCall' && item.tool === 'closeAgent')
           closeStatus = item.status
       }
+      if (message.method === 'turn/completed' && message.params.threadId !== threadId)
+        childTurnCompleted = message.params.turn
       if (message.method === 'turn/completed' && message.params.threadId === threadId) break
     }
 
     assert.ok(childThreadId)
     assert.equal(waitStatus, 'failed')
     assert.equal(closeStatus, 'failed')
+    assert.ok(childTurnCompleted)
+    assert.equal(childTurnCompleted.status, 'failed')
+    assert.equal(childTurnCompleted.itemsView, 'notLoaded')
+    assert.deepEqual(childTurnCompleted.items, [])
     proc.stdin.write(
       json({ id: 3, method: 'thread/turns/list', params: { threadId: childThreadId } }),
     )

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -1624,6 +1624,88 @@ test('startup recovery terminalizes persisted in-progress item liveness', async 
   }
 })
 
+test('startup recovery repairs stale items on already-terminal turns and is idempotent', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const store = new SessionStore(join(home, 'state.sqlite'))
+  const threadId = randomUUID()
+  const turnId = randomUUID()
+  try {
+    store.upsertThread({
+      id: threadId,
+      sessionId: threadId,
+      forkedFromId: null,
+      preview: 'terminal item recovery',
+      name: null,
+      archived: false,
+      cwd: process.cwd(),
+      model: 'sonnet',
+      reasoningEffort: null,
+      modelProvider: 'claude-code',
+      claudeSessionId: null,
+      source: 'appServer',
+      createdAt: Math.floor(Date.now() / 1000) - 2,
+      updatedAt: Math.floor(Date.now() / 1000) - 2,
+      status: { type: 'active', activeFlags: [] },
+      approvalPolicy: 'on-request',
+      sandboxMode: 'workspace-write',
+      ephemeral: false,
+      threadSource: 'user',
+      agentRole: null,
+      agentNickname: null,
+      baseInstructions: null,
+      developerInstructions: null,
+      personality: null,
+      runtimeBackend: 'claude',
+      codexSessionId: null,
+    })
+    store.upsertTurn({
+      id: turnId,
+      threadId,
+      status: 'interrupted',
+      startedAt: Math.floor(Date.now() / 1000) - 2,
+      completedAt: Math.floor(Date.now() / 1000) - 1,
+      durationMs: 1000,
+      items: [
+        {
+          type: 'subAgentActivity',
+          id: randomUUID(),
+          kind: 'started',
+          agentThreadId: randomUUID(),
+          agentPath: '/root/stale',
+        },
+        {
+          type: 'commandExecution',
+          id: randomUUID(),
+          command: 'echo stale',
+          cwd: process.cwd(),
+          processId: null,
+          source: 'shell',
+          status: 'inProgress',
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      ],
+      diff: '',
+      error: { message: 'already interrupted' },
+    })
+
+    assert.equal(store.recoverStaleInProgressTurns(), 1)
+    const recovered = store.getTurn(turnId)
+    assert.ok(recovered)
+    assert.equal(
+      recovered.items.find((item) => item.type === 'subAgentActivity')?.kind,
+      'interrupted',
+    )
+    assert.equal(recovered.items.find((item) => item.type === 'commandExecution')?.status, 'failed')
+    assert.equal(store.recoverStaleInProgressTurns(), 0)
+  } finally {
+    store.close()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
 test('app-server proxy forwards websocket handshake bytes to unix daemon', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   // Keep the socket path short — a mkdtemp dir nested under macOS tmpdir blows

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3465,7 +3465,11 @@ test('Codex cc 26.818 settles subagents without the unsupported completed activi
     assert.ok(waitCompleted)
     assert.equal(waitCompleted.status, 'completed')
     assert.equal(waitCompleted.agentsStates[childThreadId].status, 'completed')
-    assert.equal(sawCloseAgent, false)
+    assert.equal(
+      sawCloseAgent,
+      true,
+      "legacy Codex cc needs closeAgent to clear the child spinner when completed activity is unsupported",
+    )
   } finally {
     proc.kill()
     await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -2776,16 +2776,11 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       'standard subagent discovery must return the child for its parent',
     )
 
-    // All standard subagent source-kind variants describe the same persisted
-    // child relationship in this adapter. The omitted sortKey also exercises
-    // the protocol default (created_at).
-    for (const [index, sourceKind] of [
-      'subAgent',
-      'subAgentReview',
-      'subAgentCompact',
-      'subAgentThreadSpawn',
-      'subAgentOther',
-    ].entries()) {
+    // Generic and thread-spawn source kinds are representable by this
+    // adapter. The omitted sortKey also exercises the protocol default
+    // (created_at). Other variants are intentionally unsupported because the
+    // persisted schema has no discriminator for them.
+    for (const [index, sourceKind] of ['subAgent', 'subAgentThreadSpawn'].entries()) {
       const id = 80 + index
       proc.stdin.write(
         json({
@@ -2803,6 +2798,26 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
         variant.result.data.map((thread: any) => thread.id),
         [childThreadId],
         `${sourceKind} should discover the subagent child`,
+      )
+    }
+    for (const [index, sourceKind] of [
+      'subAgentReview',
+      'subAgentCompact',
+      'subAgentOther',
+    ].entries()) {
+      const id = 90 + index
+      proc.stdin.write(
+        json({
+          id,
+          method: 'thread/list',
+          params: { parentThreadId: threadId, sourceKinds: [sourceKind], limit: 200 },
+        }),
+      )
+      const variant = await reader.nextResponse(id)
+      assert.deepEqual(
+        variant.result.data.map((thread: any) => thread.id),
+        [],
+        `${sourceKind} should not mislabel a thread-spawn child`,
       )
     }
   } finally {

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3500,8 +3500,8 @@ test('Codex cc 26.818 settles subagents without the unsupported completed activi
     assert.equal(waitCompleted.agentsStates[childThreadId].status, 'completed')
     assert.equal(
       sawCloseAgent,
-      true,
-      'legacy Codex cc needs closeAgent to clear the child spinner when completed activity is unsupported',
+      false,
+      'successful legacy subagents must keep wait/completed as the visible terminal state',
     )
 
     proc.stdin.write(

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3202,6 +3202,22 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
       'the real subagent body must still be there',
     )
 
+    // A same-process late-opened parent must replay a terminal activity, not
+    // the stale started marker that drives the App spinner.
+    proc.stdin.write(
+      json({ id: 8, method: 'thread/turns/list', params: { threadId, itemsView: 'full' } }),
+    )
+    const liveParentTurns = await reader.nextResponse(8)
+    const liveActivityKinds = (liveParentTurns.result.data as any[])
+      .flatMap((turn: any) => turn.items ?? [])
+      .filter((item: any) => item.type === 'subAgentActivity')
+      .map((item: any) => item.kind)
+    assert.deepEqual(
+      liveActivityKinds,
+      ['completed'],
+      'same-process parent history must not retain a started activity marker',
+    )
+
     assert.equal(leakedInnerItems, 0, 'inner Bash tool calls should not appear at the parent level')
     assert.doesNotMatch(
       agentMessageText,

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -82,6 +82,7 @@ test('server dispatch covers current Codex app-server client method surface', as
     'model/list',
     'modelProvider/capabilities/read',
     'experimentalFeature/list',
+    'permissionProfile/list',
     'experimentalFeature/enablement/set',
     'collaborationMode/list',
     'mock/experimentalMethod',
@@ -144,6 +145,17 @@ test('stdio initialize -> thread/start -> turn/start streams mock response', asy
     assert.equal(init.result.platformFamily, process.platform === 'win32' ? 'windows' : 'unix')
 
     proc.stdin.write(
+      json({ id: 4, method: 'permissionProfile/list', params: { limit: 100, cursor: null } }),
+    )
+    const permissionProfiles = await reader.nextResponse(4)
+    assert.deepEqual(permissionProfiles.result.data, [
+      { id: ':read-only', description: null, allowed: true },
+      { id: ':workspace', description: null, allowed: true },
+      { id: ':danger-full-access', description: null, allowed: true },
+    ])
+    assert.equal(permissionProfiles.result.nextCursor, null)
+
+    proc.stdin.write(
       json({
         id: 2,
         method: 'thread/start',
@@ -153,6 +165,7 @@ test('stdio initialize -> thread/start -> turn/start streams mock response', asy
     const start = await reader.nextResponse(2)
     const threadId = start.result.thread.id
     assert.equal(start.result.modelProvider, 'claude-code')
+    assert.equal(start.result.thread.isPinned, false)
 
     proc.stdin.write(
       json({
@@ -1439,6 +1452,69 @@ test('unix daemon recovers stale in-progress turns after process restart', async
   }
 })
 
+test('stdio app-server recovers stale in-progress turns after process restart', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  let proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+  })
+  try {
+    const reader1 = new JsonLineReader(proc)
+    proc.stdin.write(
+      json({
+        id: 1,
+        method: 'thread/start',
+        params: { cwd: process.cwd(), experimentalRawEvents: false, persistExtendedHistory: false },
+      }),
+    )
+    const start = await reader1.nextResponse(1)
+    const threadId = start.result.thread.id
+    proc.stdin.write(
+      json({
+        id: 2,
+        method: 'turn/start',
+        params: {
+          threadId,
+          input: [
+            {
+              type: 'text',
+              text: `stdio stale restart check ${'x'.repeat(20_000)}`,
+              text_elements: [],
+            },
+          ],
+        },
+      }),
+    )
+    const turnStart = await reader1.nextResponse(2)
+    const turnId = turnStart.result.turn.id
+
+    proc.kill('SIGKILL')
+    await Promise.race([
+      once(proc, 'exit'),
+      delay(2000).then(() => {
+        throw new Error('timed out waiting for killed stdio adapter to exit')
+      }),
+    ])
+
+    proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+    })
+    const reader2 = new JsonLineReader(proc)
+    proc.stdin.write(
+      json({ id: 3, method: 'thread/read', params: { threadId, includeTurns: true } }),
+    )
+    const read = await reader2.nextResponse(3)
+    assert.equal(read.result.thread.status.type, 'idle')
+    const recoveredTurn = read.result.thread.turns.find((turn: any) => turn.id === turnId)
+    assert.equal(recoveredTurn.status, 'interrupted')
+    assert.match(recoveredTurn.error.message, /server restarted before completing turn/)
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
 test('app-server proxy forwards websocket handshake bytes to unix daemon', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   // Keep the socket path short — a mkdtemp dir nested under macOS tmpdir blows
@@ -2486,7 +2562,7 @@ test('Codex App approvalPolicy=never + sandbox=danger-full-access auto-accepts t
   }
 })
 
-test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeline with hidden inner events', async () => {
+test('Task subagent emits the canonical activity lifecycle and leaves wait as the terminal display state', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -2494,6 +2570,17 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
   })
   const reader = new JsonLineReader(proc)
   try {
+    proc.stdin.write(
+      json({
+        id: 0,
+        method: 'initialize',
+        params: {
+          clientInfo: { name: 'codex-test-modern', title: 'Codex test', version: 'modern' },
+          capabilities: { subAgentActivityCompleted: true },
+        },
+      }),
+    )
+    await reader.nextResponse(0)
     proc.stdin.write(
       json({
         id: 1,
@@ -2518,12 +2605,17 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
     let agentMessageText = ''
     let childThreadStarted: any = null
     let childTurnStarted: any = null
+    let childPromptStarted: any = null
+    let childPromptCompleted: any = null
     let childAgentStarted: any = null
     let childAgentCompleted: any = null
     let childAgentMessageText = ''
     let childTurnCompleted: any = null
     let liveChildRead: any = null
     let leakedInnerItems = 0
+    const subagentActivityStarted = new Map<string, any>()
+    const subagentActivities: any[] = []
+    const parentCompletedOrder: string[] = []
     for (let i = 0; i < 300; i += 1) {
       const message = await reader.next()
       if (message.id === 50) liveChildRead = message.result.thread
@@ -2545,8 +2637,12 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       }
       if (message.method === 'item/started') {
         const item = message.params.item
-        if (message.params.threadId !== threadId && item.type === 'agentMessage') {
+        if (message.params.threadId !== threadId && item.type === 'userMessage') {
+          childPromptStarted = item
+        } else if (message.params.threadId !== threadId && item.type === 'agentMessage') {
           childAgentStarted = item
+        } else if (item.type === 'subAgentActivity') {
+          subagentActivityStarted.set(item.id, item)
         } else if (item.type === 'collabAgentToolCall') {
           const bucket = (collabByTool[item.tool] ??= {})
           bucket.started = item
@@ -2559,11 +2655,17 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       }
       if (message.method === 'item/completed') {
         const item = message.params.item
-        if (message.params.threadId !== threadId && item.type === 'agentMessage') {
+        if (message.params.threadId !== threadId && item.type === 'userMessage') {
+          childPromptCompleted = item
+        } else if (message.params.threadId !== threadId && item.type === 'agentMessage') {
           childAgentCompleted = item
+        } else if (item.type === 'subAgentActivity') {
+          subagentActivities.push(item)
+          parentCompletedOrder.push(`activity:${item.kind}`)
         } else if (item.type === 'collabAgentToolCall') {
           const bucket = (collabByTool[item.tool] ??= {})
           bucket.completed = item
+          parentCompletedOrder.push(`collab:${item.tool}`)
         }
       }
       if (message.method === 'item/agentMessage/delta') {
@@ -2579,9 +2681,10 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       }
     }
 
-    // All three native lifecycle pairs must appear, each with a started AND
-    // a completed for the same id, so Codex App can render the timeline.
-    for (const tool of ['spawnAgent', 'wait', 'closeAgent']) {
+    // Native V2 uses activity items for liveness and leaves wait/completed as
+    // the final parent item. Closing an already-finished child makes older App
+    // reducers discard that completed state and fall back to "started".
+    for (const tool of ['spawnAgent', 'wait']) {
       const lc = collabByTool[tool]
       assert.ok(lc?.started, `expected item/started for ${tool}`)
       assert.ok(lc?.completed, `expected item/completed for ${tool}`)
@@ -2600,6 +2703,33 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       'spawnAgent end should reference exactly one child thread',
     )
     const childThreadId = spawnEnd.receiverThreadIds[0]!
+    assert.deepEqual(
+      subagentActivities.map((item) => item.kind),
+      ['started', 'completed'],
+      'subagent activity must transition from started to completed',
+    )
+    assert.equal(subagentActivities[0].agentThreadId, childThreadId)
+    assert.equal(subagentActivities[1].agentThreadId, childThreadId)
+    assert.equal(subagentActivities[0].agentPath, subagentActivities[1].agentPath)
+    assert.match(subagentActivities[0].agentPath, /^\/root\/[A-Za-z0-9_-]+$/)
+    assert.equal(subagentActivityStarted.size, 2)
+    for (const completedActivity of subagentActivities) {
+      assert.deepEqual(
+        subagentActivityStarted.get(completedActivity.id),
+        completedActivity,
+        `${completedActivity.kind} activity must emit item/started and item/completed with the same id`,
+      )
+    }
+    assert.ok(
+      parentCompletedOrder.indexOf('activity:completed') <
+        parentCompletedOrder.indexOf('collab:wait'),
+      'completed activity must arrive before wait/completed so the bundled App keeps the final done state',
+    )
+    assert.equal(
+      collabByTool.closeAgent,
+      undefined,
+      'a naturally completed child must not receive a synthetic closeAgent lifecycle',
+    )
     assert.ok(childThreadStarted, 'subagent must emit child thread/started for live navigation')
     assert.equal(childThreadStarted.id, childThreadId)
     assert.equal(
@@ -2623,6 +2753,10 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
     assert.equal(childTurnStarted.status, 'inProgress')
     assert.equal(childTurnStarted.itemsView, 'notLoaded')
     assert.deepEqual(childTurnStarted.items, [])
+    assert.ok(childPromptStarted, 'subagent prompt must emit child userMessage item/started')
+    assert.ok(childPromptCompleted, 'subagent prompt must emit child userMessage item/completed')
+    assert.equal(childPromptStarted.id, childPromptCompleted.id)
+    assert.equal(childPromptCompleted.content[0].text, 'investigate')
     assert.ok(liveChildRead, 'opening a running subagent must return its child turn')
     assert.equal(liveChildRead.turns.length, 1)
     assert.equal(liveChildRead.turns[0].status, 'inProgress')
@@ -2656,15 +2790,11 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
     assert.equal(childTurnCompleted.items[0].type, 'agentMessage')
     assert.equal(childTurnCompleted.items[0].id, childAgentCompleted.id)
     assert.match(childTurnCompleted.items[0].text, /subagent final summary/)
-    // After spawnAgent ends the subagent is now running; only wait/closeAgent
-    // ends report the agent as completed.
+    // After spawnAgent ends the subagent is now running; wait/completed is the
+    // terminal display snapshot after the activity completion event.
     assert.equal(spawnEnd.agentsStates[childThreadId]!.status, 'running')
     assert.equal(collabByTool.wait!.started!.receiverThreadIds[0], childThreadId)
     assert.equal(collabByTool.wait!.completed!.agentsStates[childThreadId]!.status, 'completed')
-    assert.equal(
-      collabByTool.closeAgent!.completed!.agentsStates[childThreadId]!.status,
-      'completed',
-    )
     // collabAgentToolCall.model carries the SDK model the subagent runs on,
     // NOT Claude's subagent_type — the App's "Agent · model" badge depends
     // on this. The mock runs without a subagent_type so the parent's model
@@ -2820,13 +2950,178 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
         `${sourceKind} should not mislabel a thread-spawn child`,
       )
     }
+
+    // Restart the adapter and replay the parent turn from SQLite. The bundled
+    // App reduces items in persisted order, so wait/completed must still be
+    // the last subagent state after a cold restart.
+    const exited = once(proc, 'exit')
+    proc.kill()
+    await exited
+    const restarted = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+    })
+    const restartedReader = new JsonLineReader(restarted)
+    try {
+      restarted.stdin.write(
+        json({
+          id: 1,
+          method: 'thread/turns/list',
+          params: { threadId, itemsView: 'full' },
+        }),
+      )
+      const persistedTurns = await restartedReader.nextResponse(1)
+      const persistedItems = persistedTurns.result.data[0].items.filter(
+        (item: any) => item.type === 'subAgentActivity' || item.type === 'collabAgentToolCall',
+      )
+      assert.deepEqual(
+        persistedItems.map((item: any) =>
+          item.type === 'subAgentActivity'
+            ? `activity:${item.kind}`
+            : `collab:${item.tool}:${item.status}`,
+        ),
+        [
+          'collab:spawnAgent:completed',
+          'activity:started',
+          'activity:completed',
+          'collab:wait:completed',
+        ],
+      )
+
+      restarted.stdin.write(
+        json({
+          id: 2,
+          method: 'thread/list',
+          params: {
+            parentThreadId: threadId,
+            sourceKinds: ['subAgentThreadSpawn'],
+            sortDirection: 'desc',
+            sortKey: 'created_at',
+            useStateDbOnly: true,
+            limit: 200,
+          },
+        }),
+      )
+      const rediscovered = await restartedReader.nextResponse(2)
+      assert.deepEqual(
+        rediscovered.result.data.map((thread: any) => thread.id),
+        [childThreadId],
+        'a cold App connection must rediscover the persisted subagent child',
+      )
+      assert.equal(rediscovered.result.data[0].status.type, 'idle')
+      assert.equal(rediscovered.result.data[0].isPinned, false)
+
+      restarted.stdin.write(
+        json({
+          id: 3,
+          method: 'thread/read',
+          params: { threadId: childThreadId, includeTurns: true },
+        }),
+      )
+      const coldChild = (await restartedReader.nextResponse(3)).result.thread
+      assert.equal(coldChild.turns.length, 1)
+      assert.equal(coldChild.turns[0].status, 'completed')
+      assert.equal(
+        coldChild.turns[0].items.find((item: any) => item.type === 'userMessage').content[0].text,
+        'investigate',
+      )
+      assert.match(
+        coldChild.turns[0].items.find((item: any) => item.type === 'agentMessage').text,
+        /subagent final summary/,
+      )
+    } finally {
+      restarted.kill()
+    }
   } finally {
     proc.kill()
     await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
   }
 })
 
-test('subagent without a terminal result is closed as failed', async () => {
+test('Codex cc 26.818 settles subagents without the unsupported completed activity kind', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+  })
+  const reader = new JsonLineReader(proc)
+  try {
+    proc.stdin.write(
+      json({
+        id: 0,
+        method: 'initialize',
+        params: {
+          clientInfo: {
+            name: 'Codex Desktop',
+            title: 'Codex Desktop',
+            version: '26.818.61809',
+          },
+          capabilities: { experimentalApi: true },
+        },
+      }),
+    )
+    await reader.nextResponse(0)
+    proc.stdin.write(json({ id: 1, method: 'thread/start', params: { cwd: process.cwd() } }))
+    const threadId = (await reader.nextResponse(1)).result.thread.id
+    proc.stdin.write(
+      json({
+        id: 2,
+        method: 'turn/start',
+        params: {
+          threadId,
+          input: [{ type: 'text', text: 'subagent check', text_elements: [] }],
+        },
+      }),
+    )
+    await reader.nextResponse(2)
+
+    const activityKinds: string[] = []
+    let childThreadId = ''
+    let childPromptStarted: any = null
+    let childPromptCompleted: any = null
+    let waitCompleted: any = null
+    let sawCloseAgent = false
+    for (let i = 0; i < 300; i += 1) {
+      const message = await reader.next()
+      if (message.method === 'item/started') {
+        const item = message.params.item
+        if (message.params.threadId !== threadId && item.type === 'userMessage') {
+          childPromptStarted = item
+        }
+        if (item.type === 'collabAgentToolCall' && item.tool === 'closeAgent') sawCloseAgent = true
+      }
+      if (message.method === 'item/completed') {
+        const item = message.params.item
+        if (message.params.threadId !== threadId && item.type === 'userMessage') {
+          childPromptCompleted = item
+        }
+        if (item.type === 'subAgentActivity') activityKinds.push(item.kind)
+        if (item.type === 'collabAgentToolCall' && item.tool === 'spawnAgent') {
+          childThreadId = String(item.receiverThreadIds[0] ?? '')
+        }
+        if (item.type === 'collabAgentToolCall' && item.tool === 'wait') waitCompleted = item
+        if (item.type === 'collabAgentToolCall' && item.tool === 'closeAgent') sawCloseAgent = true
+      }
+      if (message.method === 'turn/completed' && message.params.threadId === threadId) break
+    }
+
+    assert.deepEqual(activityKinds, ['started'])
+    assert.ok(childPromptStarted)
+    assert.ok(childPromptCompleted)
+    assert.equal(childPromptStarted.id, childPromptCompleted.id)
+    assert.equal(childPromptCompleted.content[0].text, 'investigate')
+    assert.ok(childThreadId)
+    assert.ok(waitCompleted)
+    assert.equal(waitCompleted.status, 'completed')
+    assert.equal(waitCompleted.agentsStates[childThreadId].status, 'completed')
+    assert.equal(sawCloseAgent, false)
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
+test('subagent without a terminal result emits interrupted activity and failed wait', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -2856,7 +3151,8 @@ test('subagent without a terminal result is closed as failed', async () => {
 
     let childThreadId = ''
     let waitStatus = ''
-    let closeStatus = ''
+    let sawClose = false
+    const activityKinds: string[] = []
     let childTurnCompleted: any = null
     for (let i = 0; i < 200; i += 1) {
       const message = await reader.next()
@@ -2865,8 +3161,8 @@ test('subagent without a terminal result is closed as failed', async () => {
         if (item.type === 'collabAgentToolCall' && item.tool === 'spawnAgent')
           childThreadId = String(item.receiverThreadIds[0] ?? '')
         if (item.type === 'collabAgentToolCall' && item.tool === 'wait') waitStatus = item.status
-        if (item.type === 'collabAgentToolCall' && item.tool === 'closeAgent')
-          closeStatus = item.status
+        if (item.type === 'collabAgentToolCall' && item.tool === 'closeAgent') sawClose = true
+        if (item.type === 'subAgentActivity') activityKinds.push(item.kind)
       }
       if (message.method === 'turn/completed' && message.params.threadId !== threadId)
         childTurnCompleted = message.params.turn
@@ -2875,7 +3171,8 @@ test('subagent without a terminal result is closed as failed', async () => {
 
     assert.ok(childThreadId)
     assert.equal(waitStatus, 'failed')
-    assert.equal(closeStatus, 'failed')
+    assert.equal(sawClose, false)
+    assert.deepEqual(activityKinds, ['started', 'interrupted'])
     assert.ok(childTurnCompleted)
     assert.equal(childTurnCompleted.status, 'failed')
     assert.equal(childTurnCompleted.itemsView, 'notLoaded')
@@ -3937,13 +4234,13 @@ test('runtime settlement cannot overwrite an interrupted turn', async () => {
         )
         assert.equal(completions.length, 1)
         assert.equal(completions[0].params.turn.status, 'interrupted')
-        const closeIndex = messages.findIndex(
+        const interruptedActivityIndex = messages.findIndex(
           (message) =>
             'method' in message &&
             message.method === 'item/completed' &&
             message.params.turnId === turnId &&
-            message.params.item.type === 'collabAgentToolCall' &&
-            message.params.item.tool === 'closeAgent',
+            message.params.item.type === 'subAgentActivity' &&
+            message.params.item.kind === 'interrupted',
         )
         const terminalIndex = messages.findIndex(
           (message) =>
@@ -3951,9 +4248,9 @@ test('runtime settlement cannot overwrite an interrupted turn', async () => {
             message.method === 'turn/completed' &&
             message.params.turn.id === turnId,
         )
-        assert.ok(closeIndex >= 0)
-        assert.ok(closeIndex < terminalIndex)
-        assert.equal(messages[closeIndex].deliveredTo, 'peer-reconnected')
+        assert.ok(interruptedActivityIndex >= 0)
+        assert.ok(interruptedActivityIndex < terminalIndex)
+        assert.equal(messages[interruptedActivityIndex].deliveredTo, 'peer-reconnected')
         assert.equal(messages[terminalIndex].deliveredTo, 'peer-reconnected')
         assert.equal(
           messages
@@ -3963,8 +4260,7 @@ test('runtime settlement cannot overwrite an interrupted turn', async () => {
                 message.method === 'item/completed' &&
                 message.params.turnId === turnId &&
                 message.params.item.type === 'collabAgentToolCall' &&
-                (message.params.item.tool === 'wait' ||
-                  message.params.item.tool === 'closeAgent'),
+                message.params.item.tool === 'wait',
             )
             .every((message) => message.deliveredTo === 'peer-reconnected'),
           true,

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -2518,12 +2518,38 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
     type Lifecycle = { started?: any; completed?: any }
     const collabByTool: Record<string, Lifecycle> = {}
     let agentMessageText = ''
+    let childThreadStarted: any = null
+    let childTurnStarted: any = null
+    let childAgentStarted: any = null
+    let childAgentCompleted: any = null
+    let childAgentMessageText = ''
+    let childTurnCompleted: any = null
+    let liveChildRead: any = null
     let leakedInnerItems = 0
     for (let i = 0; i < 300; i += 1) {
       const message = await reader.next()
+      if (message.id === 50) liveChildRead = message.result.thread
+      if (
+        message.method === 'thread/started' &&
+        message.params.thread?.threadSource === 'subagent'
+      ) {
+        childThreadStarted = message.params.thread
+      }
+      if (message.method === 'turn/started' && message.params.threadId !== threadId) {
+        childTurnStarted = message.params.turn
+        proc.stdin.write(
+          json({
+            id: 50,
+            method: 'thread/read',
+            params: { threadId: message.params.threadId, includeTurns: true },
+          }),
+        )
+      }
       if (message.method === 'item/started') {
         const item = message.params.item
-        if (item.type === 'collabAgentToolCall') {
+        if (message.params.threadId !== threadId && item.type === 'agentMessage') {
+          childAgentStarted = item
+        } else if (item.type === 'collabAgentToolCall') {
           const bucket = (collabByTool[item.tool] ??= {})
           bucket.started = item
         } else if (
@@ -2535,14 +2561,24 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       }
       if (message.method === 'item/completed') {
         const item = message.params.item
-        if (item.type === 'collabAgentToolCall') {
+        if (message.params.threadId !== threadId && item.type === 'agentMessage') {
+          childAgentCompleted = item
+        } else if (item.type === 'collabAgentToolCall') {
           const bucket = (collabByTool[item.tool] ??= {})
           bucket.completed = item
         }
       }
-      if (message.method === 'item/agentMessage/delta')
-        agentMessageText += String(message.params.delta ?? '')
-      if (message.method === 'turn/completed') break
+      if (message.method === 'item/agentMessage/delta') {
+        if (message.params.threadId === threadId) {
+          agentMessageText += String(message.params.delta ?? '')
+        } else {
+          childAgentMessageText += String(message.params.delta ?? '')
+        }
+      }
+      if (message.method === 'turn/completed') {
+        if (message.params.threadId === threadId) break
+        childTurnCompleted = message.params.turn
+      }
     }
 
     // All three native lifecycle pairs must appear, each with a started AND
@@ -2566,6 +2602,38 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       'spawnAgent end should reference exactly one child thread',
     )
     const childThreadId = spawnEnd.receiverThreadIds[0]!
+    assert.ok(childThreadStarted, 'subagent must emit child thread/started for live navigation')
+    assert.equal(childThreadStarted.id, childThreadId)
+    assert.ok(childTurnStarted, 'subagent must emit child turn/started before its result')
+    assert.equal(childTurnStarted.status, 'inProgress')
+    assert.equal(childTurnStarted.itemsView, 'notLoaded')
+    assert.deepEqual(childTurnStarted.items, [])
+    assert.ok(liveChildRead, 'opening a running subagent must return its child turn')
+    assert.equal(liveChildRead.turns.length, 1)
+    assert.equal(liveChildRead.turns[0].status, 'inProgress')
+    const liveItems = liveChildRead.turns[0].items
+    assert.equal(
+      liveItems.find((item: any) => item.type === 'userMessage').content[0].text,
+      'investigate',
+    )
+    assert.equal(
+      liveItems.some((item: any) => item.type === 'agentMessage'),
+      false,
+    )
+    assert.ok(childAgentStarted, 'subagent result must emit child agentMessage item/started')
+    assert.equal(childAgentStarted.text, '')
+    assert.match(childAgentMessageText, /subagent final summary/)
+    assert.ok(childAgentCompleted, 'subagent result must emit child agentMessage item/completed')
+    assert.equal(childAgentCompleted.id, childAgentStarted.id)
+    assert.match(childAgentCompleted.text, /subagent final summary/)
+    assert.ok(
+      childTurnCompleted,
+      'subagent must emit child turn/completed before parent completion',
+    )
+    assert.equal(childTurnCompleted.id, childTurnStarted.id)
+    assert.equal(childTurnCompleted.status, 'completed')
+    assert.equal(childTurnCompleted.itemsView, 'notLoaded')
+    assert.deepEqual(childTurnCompleted.items, [])
     // After spawnAgent ends the subagent is now running; only wait/closeAgent
     // ends report the agent as completed.
     assert.equal(spawnEnd.agentsStates[childThreadId]!.status, 'running')
@@ -2611,7 +2679,10 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       json({ id: 6, method: 'thread/turns/list', params: { threadId: childThreadId } }),
     )
     const childTurns = await reader.nextResponse(6)
+    assert.equal(childTurns.result.data.length, 1, 'subagent should use one live child turn')
     const childTurnItems = (childTurns.result.data[0] as any).items
+    const childPrompt = childTurnItems.find((i: any) => i.type === 'userMessage')
+    assert.equal(childPrompt.content[0].text, 'investigate')
     const childAgent = childTurnItems.find((i: any) => i.type === 'agentMessage')
     assert.ok(childAgent, 'child thread should have an agentMessage with the subagent result')
     assert.doesNotMatch(
@@ -2706,7 +2777,7 @@ test('subagent without a terminal result is closed as failed', async () => {
         if (item.type === 'collabAgentToolCall' && item.tool === 'closeAgent')
           closeStatus = item.status
       }
-      if (message.method === 'turn/completed') break
+      if (message.method === 'turn/completed' && message.params.threadId === threadId) break
     }
 
     assert.ok(childThreadId)
@@ -2751,7 +2822,8 @@ test('bare /workflows lists prior workflow runs without invoking the model', asy
     )
     await reader.nextResponse(2)
     for (let i = 0; i < 300; i += 1) {
-      if ((await reader.next()).method === 'turn/completed') break
+      const message = await reader.next()
+      if (message.method === 'turn/completed' && message.params.threadId === threadId) break
     }
 
     proc.stdin.write(

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { type ChildProcess, execFileSync, spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { once } from 'node:events'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import http from 'node:http'
 import net from 'node:net'
 import { tmpdir } from 'node:os'
@@ -3704,7 +3704,13 @@ test('runtime settlement cannot overwrite an interrupted turn', async () => {
         async stop() {},
       })
       const messages = []
-      const peer = { id: 'peer', send: (message) => messages.push(message), close() {} }
+      const peer = {
+        id: 'peer',
+        send(message) {
+          messages.push({ ...message, deliveredTo: 'peer' })
+        },
+        close() {},
+      }
       const response = (id) => messages.find((message) => 'id' in message && message.id === id)
       const waitFor = async (condition) => {
         for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -3733,7 +3739,20 @@ test('runtime settlement cannot overwrite an interrupted turn', async () => {
         const turnId = response(requestId).result.turn.id
         await waitFor(() => controls.has(turnId))
         outcomes.set(threadId, outcome)
-        await server.handle(peer, {
+        const interruptPeer = {
+          id: 'peer-reconnected',
+          send(message) {
+            messages.push({ ...message, deliveredTo: 'peer-reconnected' })
+          },
+          close() {},
+        }
+        server.closePeer(peer)
+        await server.handle(interruptPeer, {
+          id: ++requestId,
+          method: 'thread/resume',
+          params: { threadId },
+        })
+        await server.handle(interruptPeer, {
           id: ++requestId,
           method: 'turn/interrupt',
           params: { threadId, turnId },
@@ -3765,6 +3784,22 @@ test('runtime settlement cannot overwrite an interrupted turn', async () => {
         )
         assert.ok(closeIndex >= 0)
         assert.ok(closeIndex < terminalIndex)
+        assert.equal(messages[closeIndex].deliveredTo, 'peer-reconnected')
+        assert.equal(messages[terminalIndex].deliveredTo, 'peer-reconnected')
+        assert.equal(
+          messages
+            .filter(
+              (message) =>
+                'method' in message &&
+                message.method === 'item/completed' &&
+                message.params.turnId === turnId &&
+                message.params.item.type === 'collabAgentToolCall' &&
+                (message.params.item.tool === 'wait' ||
+                  message.params.item.tool === 'closeAgent'),
+            )
+            .every((message) => message.deliveredTo === 'peer-reconnected'),
+          true,
+        )
         assert.equal(
           messages.some(
             (message) =>
@@ -3779,6 +3814,142 @@ test('runtime settlement cannot overwrite an interrupted turn', async () => {
     `,
       ],
       { cwd: resolve('.'), stdio: 'pipe' },
+    )
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('interrupt during final git diff cannot overwrite an interrupted turn', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const repo = join(home, 'repo')
+  const bin = join(home, 'bin')
+  const diffStarted = join(home, 'git-diff-started')
+  const diffRelease = join(home, 'git-diff-release')
+  await mkdir(repo, { recursive: true })
+  await mkdir(bin, { recursive: true })
+  execFileSync('git', ['init'], { cwd: repo, stdio: 'ignore' })
+  const realGit = execFileSync('which', ['git'], { encoding: 'utf8' }).trim()
+  const fakeGit = join(bin, 'git')
+  await writeFile(
+    fakeGit,
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "rev-parse" ] && [ "$2" = "--is-inside-work-tree" ]; then',
+      "  printf 'true\\n'",
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "diff" ]; then',
+      '  : > "$CLAUDE_CODEX_TEST_GIT_DIFF_STARTED"',
+      '  while [ ! -f "$CLAUDE_CODEX_TEST_GIT_DIFF_RELEASE" ]; do sleep 0.01; done',
+      "  printf 'diff --git a/file b/file\\n--- a/file\\n+++ b/file\\n@@ -1 +1 @@\\n-old\\n+new\\n'",
+      '  exit 0',
+      'fi',
+      'exec "$CLAUDE_CODEX_REAL_GIT" "$@"',
+      '',
+    ].join('\n'),
+  )
+  await chmod(fakeGit, 0o755)
+
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--no-warnings',
+        '--input-type=module',
+        '-e',
+        `
+      import assert from 'node:assert/strict'
+      import { existsSync, writeFileSync } from 'node:fs'
+      import { join } from 'node:path'
+      import { CodexClaudeAppServer } from './dist/src/server.mjs'
+      import { SessionStore } from './dist/src/store.mjs'
+
+      process.env.CLAUDE_CODEX_HOME = ${JSON.stringify(home)}
+      const store = new SessionStore(join(${JSON.stringify(home)}, 'state.sqlite'))
+      const server = new CodexClaudeAppServer(store, {
+        async runTurn() {},
+        async steer() {},
+        async interrupt() {},
+        async stop() {},
+      })
+      const messages = []
+      const peer = { id: 'peer', send: (message) => messages.push(message), close() {} }
+      const response = (id) => messages.find((message) => 'id' in message && message.id === id)
+      const waitFor = async (condition) => {
+        for (let attempt = 0; attempt < 200; attempt += 1) {
+          if (condition()) return
+          await new Promise((resolve) => setTimeout(resolve, 5))
+        }
+        throw new Error('timed out waiting for final git diff')
+      }
+
+      await server.handle(peer, {
+        id: 1,
+        method: 'thread/start',
+        params: { cwd: ${JSON.stringify(repo)}, persistExtendedHistory: false },
+      })
+      const threadId = response(1).result.thread.id
+      await server.handle(peer, {
+        id: 2,
+        method: 'turn/start',
+        params: {
+          threadId,
+          input: [{ type: 'text', text: 'interrupt during final diff', text_elements: [] }],
+        },
+      })
+      const turnId = response(2).result.turn.id
+      await waitFor(() => existsSync(process.env.CLAUDE_CODEX_TEST_GIT_DIFF_STARTED))
+
+      await server.handle(peer, {
+        id: 3,
+        method: 'turn/interrupt',
+        params: { threadId, turnId },
+      })
+      writeFileSync(process.env.CLAUDE_CODEX_TEST_GIT_DIFF_RELEASE, 'continue')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      assert.equal(store.getTurn(turnId)?.status, 'interrupted')
+      const completions = messages.filter(
+        (message) =>
+          'method' in message &&
+          message.method === 'turn/completed' &&
+          message.params.turn.id === turnId,
+      )
+      assert.equal(completions.length, 1)
+      assert.equal(completions[0].params.turn.status, 'interrupted')
+      assert.equal(
+        messages.some(
+          (message) =>
+            'method' in message &&
+            message.method === 'turn/diff/updated' &&
+            message.params.turnId === turnId,
+        ),
+        false,
+      )
+      assert.equal(
+        messages.some(
+          (message) =>
+            'method' in message &&
+            message.method === 'error' &&
+            message.params.turnId === turnId,
+        ),
+        false,
+      )
+      await server.stop()
+    `,
+      ],
+      {
+        cwd: resolve('.'),
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ''}`,
+          CLAUDE_CODEX_REAL_GIT: realGit,
+          CLAUDE_CODEX_TEST_GIT_DIFF_STARTED: diffStarted,
+          CLAUDE_CODEX_TEST_GIT_DIFF_RELEASE: diffRelease,
+        },
+      },
     )
   } finally {
     await rm(home, { recursive: true, force: true })

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -2752,6 +2752,29 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       allIds.includes(childThreadId),
       'includeEphemeral=true should surface the subagent child thread',
     )
+
+    // Codex App discovers subagents after reconnect through the standard
+    // parent/source filters, without setting includeEphemeral explicitly.
+    proc.stdin.write(
+      json({
+        id: 7,
+        method: 'thread/list',
+        params: {
+          parentThreadId: threadId,
+          sourceKinds: ['subAgentThreadSpawn'],
+          sortDirection: 'desc',
+          sortKey: 'created_at',
+          useStateDbOnly: true,
+          limit: 200,
+        },
+      }),
+    )
+    const discovered = await reader.nextResponse(7)
+    assert.deepEqual(
+      discovered.result.data.map((thread: any) => thread.id),
+      [childThreadId],
+      'standard subagent discovery must return the child for its parent',
+    )
   } finally {
     proc.kill()
     await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -2775,6 +2775,36 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
       [childThreadId],
       'standard subagent discovery must return the child for its parent',
     )
+
+    // All standard subagent source-kind variants describe the same persisted
+    // child relationship in this adapter. The omitted sortKey also exercises
+    // the protocol default (created_at).
+    for (const [index, sourceKind] of [
+      'subAgent',
+      'subAgentReview',
+      'subAgentCompact',
+      'subAgentThreadSpawn',
+      'subAgentOther',
+    ].entries()) {
+      const id = 80 + index
+      proc.stdin.write(
+        json({
+          id,
+          method: 'thread/list',
+          params: {
+            parentThreadId: threadId,
+            sourceKinds: [sourceKind],
+            limit: 200,
+          },
+        }),
+      )
+      const variant = await reader.nextResponse(id)
+      assert.deepEqual(
+        variant.result.data.map((thread: any) => thread.id),
+        [childThreadId],
+        `${sourceKind} should discover the subagent child`,
+      )
+    }
   } finally {
     proc.kill()
     await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -3214,8 +3214,8 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
       .map((item: any) => item.kind)
     assert.deepEqual(
       liveActivityKinds,
-      ['completed'],
-      'same-process parent history must not retain a started activity marker',
+      [],
+      'same-process parent history must not retain capability-specific activity markers',
     )
 
     assert.equal(leakedInnerItems, 0, 'inner Bash tool calls should not appear at the parent level')
@@ -3318,9 +3318,8 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
 
     // Restart the adapter and replay the parent turn from SQLite. The bundled
     // App reduces items in persisted order, so wait/completed must still be
-    // the last subagent state after a cold restart. `completed` activity is a
-    // live-only extension; the durable history stays compatible with Codex cc
-    // 26.818, whose schema only accepts started/interacted/interrupted.
+    // the last subagent state after a cold restart. Activity markers are
+    // live-only extensions; the durable history stays capability-neutral.
     const exited = once(proc, 'exit')
     proc.kill()
     await exited

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -1772,7 +1772,7 @@ test('startup recovery repairs stale items on already-terminal turns and is idem
   }
 })
 
-test('startup recovery preserves successful legacy subagent activity history', async () => {
+test('startup recovery removes legacy activity markers from completed subagent turns', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const store = new SessionStore(join(home, 'state.sqlite'))
   const threadId = randomUUID()
@@ -1794,7 +1794,7 @@ test('startup recovery preserves successful legacy subagent activity history', a
       source: 'appServer',
       createdAt: Math.floor(Date.now() / 1000) - 2,
       updatedAt: Math.floor(Date.now() / 1000) - 2,
-      status: { type: 'idle' },
+      status: { type: 'active', activeFlags: [] },
       approvalPolicy: 'on-request',
       sandboxMode: 'workspace-write',
       ephemeral: false,
@@ -1823,6 +1823,13 @@ test('startup recovery preserves successful legacy subagent activity history', a
           agentPath: '/root/legacy',
         },
         {
+          type: 'subAgentActivity',
+          id: randomUUID(),
+          kind: 'completed',
+          agentThreadId: childThreadId,
+          agentPath: '/root/legacy',
+        },
+        {
           type: 'collabAgentToolCall',
           id: randomUUID(),
           tool: 'wait',
@@ -1839,10 +1846,12 @@ test('startup recovery preserves successful legacy subagent activity history', a
       error: null,
     })
 
-    assert.equal(store.recoverStaleInProgressTurns(), 0)
+    assert.equal(store.recoverStaleInProgressTurns(), 1)
     const recovered = store.getTurn(turnId)
     assert.ok(recovered)
-    assert.equal(recovered.items.find((item) => item.type === 'subAgentActivity')?.kind, 'started')
+    assert.equal(recovered.items.some((item) => item.type === 'subAgentActivity'), false)
+    assert.equal(store.getThread(threadId)?.status.type, 'idle')
+    assert.equal(store.recoverStaleInProgressTurns(), 0)
   } finally {
     store.close()
     await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
@@ -3322,7 +3331,8 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
             ? `activity:${item.kind}`
             : `collab:${item.tool}:${item.status}`,
         ),
-        ['collab:spawnAgent:completed', 'activity:started', 'collab:wait:completed'],
+        ['collab:spawnAgent:completed', 'collab:wait:completed'],
+        'cold-open history must not retain a started activity marker after wait/completed',
       )
 
       restarted.stdin.write(
@@ -3442,7 +3452,11 @@ test('Codex cc 26.818 settles subagents without the unsupported completed activi
       if (message.method === 'turn/completed' && message.params.threadId === threadId) break
     }
 
-    assert.deepEqual(activityKinds, ['started'])
+    assert.deepEqual(
+      activityKinds,
+      [],
+      'Codex cc 26.818 must use spawnAgent/wait lifecycle instead of an unsupported started marker',
+    )
     assert.ok(childPromptStarted)
     assert.ok(childPromptCompleted)
     assert.equal(childPromptStarted.id, childPromptCompleted.id)
@@ -3509,7 +3523,7 @@ test('subagent without a terminal result emits interrupted activity and failed w
     assert.ok(childThreadId)
     assert.equal(waitStatus, 'failed')
     assert.equal(sawClose, false)
-    assert.deepEqual(activityKinds, ['started', 'interrupted'])
+    assert.deepEqual(activityKinds, ['interrupted'])
     assert.ok(childTurnCompleted)
     assert.equal(childTurnCompleted.status, 'failed')
     assert.equal(childTurnCompleted.itemsView, 'notLoaded')
@@ -4704,6 +4718,101 @@ test('subagent watchdog terminalizes a runtime that never returns', async () => 
       assert.ok(child)
       assert.equal(store.listTurns(child.id)[0].status, 'failed')
       assert.equal(store.listTurns(threadId)[0].items.at(-1).status, 'failed')
+      await server.stop()
+    `,
+      ],
+      { cwd: resolve('.'), stdio: 'pipe' },
+    )
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('workflow watchdog terminalizes a launch that never publishes a result', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--no-warnings',
+        '--input-type=module',
+        '-e',
+        `
+      import assert from 'node:assert/strict'
+      import { join } from 'node:path'
+      import { CodexClaudeAppServer } from './dist/src/server.mjs'
+      import { SessionStore } from './dist/src/store.mjs'
+
+      process.env.CLAUDE_CODEX_HOME = ${JSON.stringify(home)}
+      process.env.CLAUDE_CODEX_SUBAGENT_TIMEOUT_MS = '100'
+      const store = new SessionStore(join(${JSON.stringify(home)}, 'state.sqlite'))
+      const interrupted = []
+      const server = new CodexClaudeAppServer(store, {
+        async runTurn(context, handlers) {
+          await handlers.onEvent({
+            type: 'tool_use',
+            toolUseId: 'workflow-' + context.turnId,
+            toolName: 'Workflow',
+            input: { command: '/workflows never returns' },
+          })
+          return new Promise(() => {})
+        },
+        async steer() {},
+        async interrupt(threadId) {
+          interrupted.push(threadId)
+        },
+        async stop() {},
+      })
+      const messages = []
+      const peer = { id: 'peer', send: (message) => messages.push(message), close() {} }
+      const response = (id) => messages.find((message) => 'id' in message && message.id === id)
+      const waitFor = async (condition) => {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if (condition()) return
+          await new Promise((resolve) => setTimeout(resolve, 10))
+        }
+        throw new Error('timed out waiting for workflow watchdog')
+      }
+
+      await server.handle(peer, {
+        id: 1,
+        method: 'thread/start',
+        params: { cwd: process.cwd(), persistExtendedHistory: false },
+      })
+      const threadId = response(1).result.thread.id
+      await server.handle(peer, {
+        id: 2,
+        method: 'turn/start',
+        params: { threadId, input: [{ type: 'text', text: '/workflows hang', text_elements: [] }] },
+      })
+      const turnId = response(2).result.turn.id
+      await waitFor(() =>
+        messages.some(
+          (message) =>
+            'method' in message &&
+            message.method === 'turn/completed' &&
+            message.params.turn.id === turnId,
+        ),
+      )
+      const completed = messages.find(
+        (message) =>
+          'method' in message &&
+          message.method === 'turn/completed' &&
+          message.params.turn.id === turnId,
+      )
+      assert.equal(completed.params.turn.status, 'failed')
+      assert.match(completed.params.turn.error.message, /terminal result within 1 second/)
+      assert.equal(interrupted.length, 1)
+      assert.equal(
+        messages.some(
+          (message) =>
+            'method' in message &&
+            message.method === 'item/started' &&
+            message.params.item.type === 'collabAgentToolCall',
+        ),
+        false,
+        'a Workflow launch without projected agents must not fabricate a child card',
+      )
       await server.stop()
     `,
       ],

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -32,6 +32,7 @@ test('server dispatch covers current Codex app-server client method surface', as
     'thread/goal/get',
     'thread/goal/clear',
     'thread/metadata/update',
+    'thread/settings/update',
     'thread/memoryMode/set',
     'memory/reset',
     'thread/unarchive',
@@ -189,6 +190,71 @@ test('stdio initialize -> thread/start -> turn/start streams mock response', asy
     }
     assert.match(deltas.join(''), /Claude Code adapter mock response/)
     assert.equal(sawAgentCompleted, true)
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
+test('permission profile selection applies full access without legacy sandbox fields', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+  })
+  const reader = new JsonLineReader(proc)
+  try {
+    proc.stdin.write(
+      json({
+        id: 1,
+        method: 'initialize',
+        params: { clientInfo: { name: 'codex-test', version: '26.818' }, capabilities: null },
+      }),
+    )
+    await reader.nextResponse(1)
+    proc.stdin.write(
+      json({
+        id: 2,
+        method: 'thread/start',
+        params: { cwd: process.cwd(), permissions: ':danger-full-access' },
+      }),
+    )
+    const start = await reader.nextResponse(2)
+    const threadId = start.result.thread.id
+    assert.equal(start.result.approvalPolicy, 'never')
+    assert.equal(start.result.sandbox.type, 'dangerFullAccess')
+    assert.deepEqual(start.result.activePermissionProfile, {
+      id: ':danger-full-access',
+      extends: null,
+    })
+    assert.equal(start.result.permissions, ':danger-full-access')
+
+    proc.stdin.write(
+      json({
+        id: 3,
+        method: 'turn/start',
+        params: {
+          threadId,
+          input: [{ type: 'text', text: 'please run approval bash', text_elements: [] }],
+          permissions: ':danger-full-access',
+        },
+      }),
+    )
+    await reader.nextResponse(3)
+    let sawApprovalRequest = false
+    let sawCommandOutput = false
+    for (let i = 0; i < 200; i += 1) {
+      const message = await reader.next()
+      if (message.method === 'item/commandExecution/requestApproval') sawApprovalRequest = true
+      if (
+        message.method === 'item/commandExecution/outputDelta' &&
+        /mock approval/.test(message.params.delta)
+      )
+        sawCommandOutput = true
+      if (message.method === 'turn/completed') break
+    }
+    assert.equal(sawApprovalRequest, false)
+    assert.equal(sawCommandOutput, true)
   } finally {
     proc.kill()
     await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
@@ -1706,6 +1772,83 @@ test('startup recovery repairs stale items on already-terminal turns and is idem
   }
 })
 
+test('startup recovery preserves successful legacy subagent activity history', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const store = new SessionStore(join(home, 'state.sqlite'))
+  const threadId = randomUUID()
+  const turnId = randomUUID()
+  const childThreadId = randomUUID()
+  try {
+    store.upsertThread({
+      id: threadId,
+      sessionId: threadId,
+      forkedFromId: null,
+      preview: 'legacy activity history',
+      name: null,
+      archived: false,
+      cwd: process.cwd(),
+      model: 'sonnet',
+      reasoningEffort: null,
+      modelProvider: 'claude-code',
+      claudeSessionId: null,
+      source: 'appServer',
+      createdAt: Math.floor(Date.now() / 1000) - 2,
+      updatedAt: Math.floor(Date.now() / 1000) - 2,
+      status: { type: 'idle' },
+      approvalPolicy: 'on-request',
+      sandboxMode: 'workspace-write',
+      ephemeral: false,
+      threadSource: 'user',
+      agentRole: null,
+      agentNickname: null,
+      baseInstructions: null,
+      developerInstructions: null,
+      personality: null,
+      runtimeBackend: 'claude',
+      codexSessionId: null,
+    })
+    store.upsertTurn({
+      id: turnId,
+      threadId,
+      status: 'completed',
+      startedAt: Math.floor(Date.now() / 1000) - 2,
+      completedAt: Math.floor(Date.now() / 1000) - 1,
+      durationMs: 1000,
+      items: [
+        {
+          type: 'subAgentActivity',
+          id: randomUUID(),
+          kind: 'started',
+          agentThreadId: childThreadId,
+          agentPath: '/root/legacy',
+        },
+        {
+          type: 'collabAgentToolCall',
+          id: randomUUID(),
+          tool: 'wait',
+          status: 'completed',
+          senderThreadId: threadId,
+          receiverThreadIds: [childThreadId],
+          prompt: null,
+          model: null,
+          reasoningEffort: null,
+          agentsStates: { [childThreadId]: { status: 'completed', message: null } },
+        },
+      ],
+      diff: '',
+      error: null,
+    })
+
+    assert.equal(store.recoverStaleInProgressTurns(), 0)
+    const recovered = store.getTurn(turnId)
+    assert.ok(recovered)
+    assert.equal(recovered.items.find((item) => item.type === 'subAgentActivity')?.kind, 'started')
+  } finally {
+    store.close()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
 test('app-server proxy forwards websocket handshake bytes to unix daemon', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   // Keep the socket path short — a mkdtemp dir nested under macOS tmpdir blows
@@ -2757,7 +2900,13 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+    env: {
+      ...process.env,
+      CODEX_HOME: home,
+      CLAUDE_CODEX_MOCK: '1',
+      CLAUDE_CODEX_SUBAGENT_COMPLETED: '1',
+      NODE_NO_WARNINGS: '1',
+    },
   })
   const reader = new JsonLineReader(proc)
   try {
@@ -3144,7 +3293,9 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
 
     // Restart the adapter and replay the parent turn from SQLite. The bundled
     // App reduces items in persisted order, so wait/completed must still be
-    // the last subagent state after a cold restart.
+    // the last subagent state after a cold restart. `completed` activity is a
+    // live-only extension; the durable history stays compatible with Codex cc
+    // 26.818, whose schema only accepts started/interacted/interrupted.
     const exited = once(proc, 'exit')
     proc.kill()
     await exited
@@ -3171,12 +3322,7 @@ test('Task subagent emits the canonical activity lifecycle and leaves wait as th
             ? `activity:${item.kind}`
             : `collab:${item.tool}:${item.status}`,
         ),
-        [
-          'collab:spawnAgent:completed',
-          'activity:started',
-          'activity:completed',
-          'collab:wait:completed',
-        ],
+        ['collab:spawnAgent:completed', 'activity:started', 'collab:wait:completed'],
       )
 
       restarted.stdin.write(
@@ -4466,6 +4612,98 @@ test('runtime settlement cannot overwrite an interrupted turn', async () => {
           false,
         )
       }
+      await server.stop()
+    `,
+      ],
+      { cwd: resolve('.'), stdio: 'pipe' },
+    )
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('subagent watchdog terminalizes a runtime that never returns', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--no-warnings',
+        '--input-type=module',
+        '-e',
+        `
+      import assert from 'node:assert/strict'
+      import { join } from 'node:path'
+      import { CodexClaudeAppServer } from './dist/src/server.mjs'
+      import { SessionStore } from './dist/src/store.mjs'
+
+      process.env.CLAUDE_CODEX_HOME = ${JSON.stringify(home)}
+      process.env.CLAUDE_CODEX_SUBAGENT_TIMEOUT_MS = '100'
+      const store = new SessionStore(join(${JSON.stringify(home)}, 'state.sqlite'))
+      const interrupted = []
+      const server = new CodexClaudeAppServer(store, {
+        async runTurn(context, handlers) {
+          await handlers.onEvent({
+            type: 'tool_use',
+            toolUseId: 'stuck-' + context.turnId,
+            toolName: 'Task',
+            input: { description: 'stuck subagent', prompt: 'never returns' },
+          })
+          return new Promise(() => {})
+        },
+        async steer() {},
+        async interrupt(threadId) {
+          interrupted.push(threadId)
+        },
+        async stop() {},
+      })
+      const messages = []
+      const peer = { id: 'peer', send: (message) => messages.push(message), close() {} }
+      const response = (id) => messages.find((message) => 'id' in message && message.id === id)
+      const waitFor = async (condition) => {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if (condition()) return
+          await new Promise((resolve) => setTimeout(resolve, 10))
+        }
+        throw new Error('timed out waiting for watchdog')
+      }
+
+      await server.handle(peer, {
+        id: 1,
+        method: 'thread/start',
+        params: { cwd: process.cwd(), persistExtendedHistory: false },
+      })
+      const threadId = response(1).result.thread.id
+      await server.handle(peer, {
+        id: 2,
+        method: 'turn/start',
+        params: { threadId, input: [{ type: 'text', text: 'hang', text_elements: [] }] },
+      })
+      const turnId = response(2).result.turn.id
+      await waitFor(() =>
+        messages.some(
+          (message) =>
+            'method' in message &&
+            message.method === 'turn/completed' &&
+            message.params.turn.id === turnId,
+        ),
+      )
+
+      const completed = messages.find(
+        (message) =>
+          'method' in message &&
+          message.method === 'turn/completed' &&
+          message.params.turn.id === turnId,
+      )
+      assert.equal(completed.params.turn.status, 'failed')
+      assert.match(completed.params.turn.error.message, /terminal result within 1 second/)
+      assert.equal(interrupted.length, 1)
+      const child = store
+        .listThreads({ includeEphemeral: true })
+        .find((candidate) => candidate.threadSource === 'subagent')
+      assert.ok(child)
+      assert.equal(store.listTurns(child.id)[0].status, 'failed')
+      assert.equal(store.listTurns(threadId)[0].items.at(-1).status, 'failed')
       await server.stop()
     `,
       ],

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -2665,6 +2665,120 @@ test('Task subagent emits Codex native spawnAgent → wait → closeAgent timeli
   }
 })
 
+test('subagent without a terminal result is closed as failed', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+  })
+  const reader = new JsonLineReader(proc)
+  try {
+    proc.stdin.write(
+      json({
+        id: 1,
+        method: 'thread/start',
+        params: { cwd: process.cwd(), persistExtendedHistory: false },
+      }),
+    )
+    const threadId = (await reader.nextResponse(1)).result.thread.id
+    proc.stdin.write(
+      json({
+        id: 2,
+        method: 'turn/start',
+        params: {
+          threadId,
+          input: [{ type: 'text', text: 'orphan subagent check', text_elements: [] }],
+        },
+      }),
+    )
+    await reader.nextResponse(2)
+
+    let childThreadId = ''
+    let waitStatus = ''
+    let closeStatus = ''
+    for (let i = 0; i < 200; i += 1) {
+      const message = await reader.next()
+      if (message.method === 'item/completed') {
+        const item = message.params.item
+        if (item.type === 'collabAgentToolCall' && item.tool === 'spawnAgent')
+          childThreadId = String(item.receiverThreadIds[0] ?? '')
+        if (item.type === 'collabAgentToolCall' && item.tool === 'wait') waitStatus = item.status
+        if (item.type === 'collabAgentToolCall' && item.tool === 'closeAgent')
+          closeStatus = item.status
+      }
+      if (message.method === 'turn/completed') break
+    }
+
+    assert.ok(childThreadId)
+    assert.equal(waitStatus, 'failed')
+    assert.equal(closeStatus, 'failed')
+    proc.stdin.write(
+      json({ id: 3, method: 'thread/turns/list', params: { threadId: childThreadId } }),
+    )
+    const childTurns = await reader.nextResponse(3)
+    assert.equal(childTurns.result.data[0].status, 'failed')
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
+test('bare /workflows lists prior workflow runs without invoking the model', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, CODEX_HOME: home, CLAUDE_CODEX_MOCK: '1', NODE_NO_WARNINGS: '1' },
+  })
+  const reader = new JsonLineReader(proc)
+  try {
+    proc.stdin.write(
+      json({
+        id: 1,
+        method: 'thread/start',
+        params: { cwd: process.cwd(), persistExtendedHistory: false },
+      }),
+    )
+    const threadId = (await reader.nextResponse(1)).result.thread.id
+    proc.stdin.write(
+      json({
+        id: 2,
+        method: 'turn/start',
+        params: {
+          threadId,
+          input: [{ type: 'text', text: '/workflows subagent check', text_elements: [] }],
+        },
+      }),
+    )
+    await reader.nextResponse(2)
+    for (let i = 0; i < 300; i += 1) {
+      if ((await reader.next()).method === 'turn/completed') break
+    }
+
+    proc.stdin.write(
+      json({
+        id: 3,
+        method: 'turn/start',
+        params: { threadId, input: [{ type: 'text', text: '/workflows', text_elements: [] }] },
+      }),
+    )
+    await reader.nextResponse(3)
+    let listText = ''
+    for (let i = 0; i < 100; i += 1) {
+      const message = await reader.next()
+      if (message.method === 'item/agentMessage/delta') listText += message.params.delta
+      if (message.method === 'turn/completed') break
+    }
+
+    assert.match(listText, /Workflow runs in this task:/)
+    assert.match(listText, /1 agent\(s\)/)
+    assert.match(listText, /subagent check/)
+    assert.doesNotMatch(listText, /Claude Code adapter mock response/)
+  } finally {
+    proc.kill()
+    await rm(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 80 })
+  }
+})
+
 test('thread/start picks up effort from config.model_reasoning_effort when top-level effort is absent', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const proc = spawn(process.execPath, [adapter, 'app-server', '--listen', 'stdio://'], {
@@ -3536,6 +3650,131 @@ test('turn interrupt completes requested in-progress turn after reconnect', asyn
       assert.deepEqual(status?.params.status, { type: 'idle' })
       const response = messages.find((message) => 'id' in message && message.id === 1)
       assert.deepEqual(response?.result, {})
+      await server.stop()
+    `,
+      ],
+      { cwd: resolve('.'), stdio: 'pipe' },
+    )
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('runtime settlement cannot overwrite an interrupted turn', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--no-warnings',
+        '--input-type=module',
+        '-e',
+        `
+      import assert from 'node:assert/strict'
+      import { join } from 'node:path'
+      import { CodexClaudeAppServer } from './dist/src/server.mjs'
+      import { SessionStore } from './dist/src/store.mjs'
+
+      process.env.CLAUDE_CODEX_HOME = ${JSON.stringify(home)}
+      const store = new SessionStore(join(${JSON.stringify(home)}, 'state.sqlite'))
+      const controls = new Map()
+      const controlsByThread = new Map()
+      const outcomes = new Map()
+      const server = new CodexClaudeAppServer(store, {
+        async runTurn(context, handlers) {
+          await handlers.onEvent({
+            type: 'tool_use',
+            toolUseId: 'active-' + context.turnId,
+            toolName: 'Task',
+            input: { description: 'active subagent', prompt: 'wait for interruption' },
+          })
+          return new Promise((resolve, reject) => {
+            const control = { resolve, reject }
+            controls.set(context.turnId, control)
+            controlsByThread.set(context.threadId, control)
+          })
+        },
+        async steer() {},
+        async interrupt(threadId) {
+          const control = controlsByThread.get(threadId)
+          if (outcomes.get(threadId) === 'resolve') control.resolve()
+          else control.reject(new Error('runtime rejected during interrupt'))
+          await new Promise((resolve) => setTimeout(resolve, 10))
+        },
+        async stop() {},
+      })
+      const messages = []
+      const peer = { id: 'peer', send: (message) => messages.push(message), close() {} }
+      const response = (id) => messages.find((message) => 'id' in message && message.id === id)
+      const waitFor = async (condition) => {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if (condition()) return
+          await new Promise((resolve) => setTimeout(resolve, 5))
+        }
+        throw new Error('timed out waiting for runtime control')
+      }
+
+      let requestId = 0
+      for (const outcome of ['resolve', 'reject']) {
+        await server.handle(peer, {
+          id: ++requestId,
+          method: 'thread/start',
+          params: { cwd: process.cwd(), persistExtendedHistory: false },
+        })
+        const threadId = response(requestId).result.thread.id
+        await server.handle(peer, {
+          id: ++requestId,
+          method: 'turn/start',
+          params: {
+            threadId,
+            input: [{ type: 'text', text: 'interrupt workflow', text_elements: [] }],
+          },
+        })
+        const turnId = response(requestId).result.turn.id
+        await waitFor(() => controls.has(turnId))
+        outcomes.set(threadId, outcome)
+        await server.handle(peer, {
+          id: ++requestId,
+          method: 'turn/interrupt',
+          params: { threadId, turnId },
+        })
+        await new Promise((resolve) => setTimeout(resolve, 25))
+
+        assert.equal(store.getTurn(turnId)?.status, 'interrupted')
+        const completions = messages.filter(
+          (message) =>
+            'method' in message &&
+            message.method === 'turn/completed' &&
+            message.params.turn.id === turnId,
+        )
+        assert.equal(completions.length, 1)
+        assert.equal(completions[0].params.turn.status, 'interrupted')
+        const closeIndex = messages.findIndex(
+          (message) =>
+            'method' in message &&
+            message.method === 'item/completed' &&
+            message.params.turnId === turnId &&
+            message.params.item.type === 'collabAgentToolCall' &&
+            message.params.item.tool === 'closeAgent',
+        )
+        const terminalIndex = messages.findIndex(
+          (message) =>
+            'method' in message &&
+            message.method === 'turn/completed' &&
+            message.params.turn.id === turnId,
+        )
+        assert.ok(closeIndex >= 0)
+        assert.ok(closeIndex < terminalIndex)
+        assert.equal(
+          messages.some(
+            (message) =>
+              'method' in message &&
+              message.method === 'error' &&
+              message.params.turnId === turnId,
+          ),
+          false,
+        )
+      }
       await server.stop()
     `,
       ],

--- a/test/adapter.test.mts
+++ b/test/adapter.test.mts
@@ -4823,6 +4823,179 @@ test('workflow watchdog terminalizes a launch that never publishes a result', as
   }
 })
 
+test('workflow watchdog disarms when the original Workflow tool result arrives', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--no-warnings',
+        '--input-type=module',
+        '-e',
+        `
+      import assert from 'node:assert/strict'
+      import { join } from 'node:path'
+      import { CodexClaudeAppServer } from './dist/src/server.mjs'
+      import { SessionStore } from './dist/src/store.mjs'
+
+      process.env.CLAUDE_CODEX_HOME = ${JSON.stringify(home)}
+      process.env.CLAUDE_CODEX_SUBAGENT_TIMEOUT_MS = '100'
+      const store = new SessionStore(join(${JSON.stringify(home)}, 'state.sqlite'))
+      const server = new CodexClaudeAppServer(store, {
+        async runTurn(context, handlers) {
+          const toolUseId = 'workflow-launch-' + context.turnId
+          await handlers.onEvent({
+            type: 'tool_use',
+            toolUseId,
+            toolName: 'Workflow',
+            input: { command: '/workflows slow result' },
+          })
+          await handlers.onEvent({ type: 'tool_result', toolUseId, content: 'launch accepted' })
+          await new Promise((resolve) => setTimeout(resolve, 250))
+          await handlers.onEvent({ type: 'completed', success: true, result: 'workflow done' })
+        },
+        async steer() {},
+        async interrupt() {},
+        async stop() {},
+      })
+      const messages = []
+      const peer = { id: 'peer', send: (message) => messages.push(message), close() {} }
+      const response = (id) => messages.find((message) => 'id' in message && message.id === id)
+      const waitFor = async (condition) => {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if (condition()) return
+          await new Promise((resolve) => setTimeout(resolve, 10))
+        }
+        throw new Error('timed out waiting for original Workflow result')
+      }
+
+      await server.handle(peer, {
+        id: 1,
+        method: 'thread/start',
+        params: { cwd: process.cwd(), persistExtendedHistory: false },
+      })
+      const threadId = response(1).result.thread.id
+      await server.handle(peer, {
+        id: 2,
+        method: 'turn/start',
+        params: { threadId, input: [{ type: 'text', text: '/workflows slow', text_elements: [] }] },
+      })
+      const turnId = response(2).result.turn.id
+      await waitFor(() =>
+        messages.some(
+          (message) =>
+            'method' in message &&
+            message.method === 'turn/completed' &&
+            message.params.turn.id === turnId,
+        ),
+      )
+      const completed = messages.find(
+        (message) =>
+          'method' in message &&
+          message.method === 'turn/completed' &&
+          message.params.turn.id === turnId,
+      )
+      assert.equal(completed.params.turn.status, 'completed')
+      assert.equal(completed.params.turn.error, null)
+      await server.stop()
+    `,
+      ],
+      { cwd: resolve('.'), stdio: 'pipe' },
+    )
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('server shutdown terminalizes active child turns before closing the store', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
+  const database = join(home, 'state.sqlite')
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '--no-warnings',
+        '--input-type=module',
+        '-e',
+        `
+      import assert from 'node:assert/strict'
+      import { join } from 'node:path'
+      import { CodexClaudeAppServer } from './dist/src/server.mjs'
+      import { SessionStore } from './dist/src/store.mjs'
+
+      process.env.CLAUDE_CODEX_HOME = ${JSON.stringify(home)}
+      const store = new SessionStore(${JSON.stringify(database)})
+      const server = new CodexClaudeAppServer(store, {
+        async runTurn(context, handlers) {
+          await handlers.onEvent({
+            type: 'tool_use',
+            toolUseId: 'shutdown-child-' + context.turnId,
+            toolName: 'Task',
+            input: { description: 'child survives shutdown', prompt: 'investigate shutdown' },
+          })
+          return new Promise(() => {})
+        },
+        async steer() {},
+        async interrupt() {},
+        async stop() {},
+      })
+      const messages = []
+      const peer = { id: 'peer', send: (message) => messages.push(message), close() {} }
+      const response = (id) => messages.find((message) => 'id' in message && message.id === id)
+      const waitFor = async (condition) => {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if (condition()) return
+          await new Promise((resolve) => setTimeout(resolve, 10))
+        }
+        throw new Error('timed out waiting for child creation')
+      }
+
+      await server.handle(peer, {
+        id: 1,
+        method: 'thread/start',
+        params: { cwd: process.cwd(), persistExtendedHistory: false },
+      })
+      const parentThreadId = response(1).result.thread.id
+      await server.handle(peer, {
+        id: 2,
+        method: 'turn/start',
+        params: { threadId: parentThreadId, input: [{ type: 'text', text: 'hang', text_elements: [] }] },
+      })
+      await waitFor(() =>
+        messages.some(
+          (message) =>
+            'method' in message &&
+            message.method === 'item/completed' &&
+            message.params.item?.tool === 'spawnAgent',
+        ),
+      )
+      await server.stop()
+
+      const reopened = new SessionStore(${JSON.stringify(database)})
+      try {
+        const child = reopened
+          .listThreads({ includeEphemeral: true })
+          .find((candidate) => candidate.threadSource === 'subagent')
+        assert.ok(child)
+        assert.equal(reopened.listTurns(child.id)[0].status, 'failed')
+        assert.equal(reopened.listTurns(parentThreadId)[0].status, 'interrupted')
+        assert.equal(reopened.listTurns(parentThreadId)[0].items.at(-1).status, 'failed')
+        assert.equal(
+          reopened.listThreads({ includeEphemeral: true }).flatMap((thread) => reopened.listTurns(thread.id)).some((turn) => turn.status === 'inProgress'),
+          false,
+        )
+      } finally {
+        reopened.close()
+      }
+    `,
+      ],
+      { cwd: resolve('.'), stdio: 'pipe' },
+    )
+  } finally {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
 test('interrupt during final git diff cannot overwrite an interrupted turn', async () => {
   const home = await mkdtemp(join(tmpdir(), 'claude-codex-test-'))
   const repo = join(home, 'repo')

--- a/test/runtime-config.test.mts
+++ b/test/runtime-config.test.mts
@@ -1,6 +1,17 @@
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import {
+  appendFile,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import http from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -15,6 +26,10 @@ import { NativeClaudeRuntime, sdkResumeSessionId } from '../src/native-runtime.m
 import { resolveRuntimeConfig } from '../src/runtime-config.mjs'
 import type { RuntimeTurnContext } from '../src/types.mjs'
 import { parseWorkflowCommand, workflowRuntimePrompt } from '../src/workflow-command.mjs'
+import {
+  defaultWorkflowTranscriptRoots,
+  WorkflowJournalMonitor,
+} from '../src/workflow-subagents.mjs'
 
 function nativeTurnContext(overrides: Partial<RuntimeTurnContext> = {}): RuntimeTurnContext {
   return {
@@ -177,6 +192,19 @@ test('workflow command parser keeps list and run semantics distinct', () => {
   assert.equal(options.settings, undefined)
 })
 
+test('workflow transcript roots follow CLAUDE_CONFIG_DIR and HOME deterministically', () => {
+  assert.deepEqual(
+    defaultWorkflowTranscriptRoots(
+      { CLAUDE_CONFIG_DIR: 'profiles/claude', HOME: '/ignored-home' },
+      '/workspace',
+    ),
+    ['/workspace/profiles/claude'],
+  )
+  assert.deepEqual(defaultWorkflowTranscriptRoots({ HOME: '/users/tester' }, '/workspace'), [
+    '/users/tester/.claude',
+  ])
+})
+
 test('manual workflow normalization preserves attached image blocks', async () => {
   const runtime = new NativeClaudeRuntime()
   const buildPromptIterable = Reflect.get(runtime, 'buildPromptIterable')
@@ -200,7 +228,1234 @@ test('manual workflow normalization preserves attached image blocks', async () =
   })
 })
 
-test('native SDK runtime maps local workflow task events to one Agent lifecycle', async () => {
+test('native SDK runtime projects workflow journal agents into separate live Agent lifecycles', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-workflow-journal-'))
+  const runId = 'wf_test_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  await mkdir(transcriptDir, { recursive: true })
+  const agents = [
+    { id: 'aaaaaaaa111111111', name: 'alpha', prompt: 'Review module alpha' },
+    { id: 'bbbbbbbb222222222', name: 'beta', prompt: 'Review module beta' },
+    { id: 'cccccccc333333333', name: 'gamma', prompt: 'Review module gamma' },
+  ]
+  for (const agent of agents) {
+    await writeFile(
+      join(transcriptDir, `agent-${agent.id}.jsonl`),
+      `${JSON.stringify({ message: { role: 'user', content: agent.prompt } })}\n`,
+    )
+  }
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set<string>(),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleAssistant = Reflect.get(runtime, 'handleAssistant')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  let notified = false
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'workflow-task-id',
+      tool_use_id: 'workflow-launch-tool',
+      task_type: 'local_workflow',
+      workflow_name: 'parallel-review',
+      description: 'Review three modules',
+    })
+    await handleAssistant.call(runtime, pending, {
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'workflow-launch-tool',
+            name: 'Workflow',
+            input: { command: 'parallel-review' },
+          },
+        ],
+      },
+    })
+    assert.equal(pending.workflowToolUseIds.has('workflow-launch-tool'), true)
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'workflow-task-id',
+        taskType: 'local_workflow',
+        workflowName: 'parallel-review',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'workflow-launch-tool',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    assert.equal(pending.workflowToolUseIds.size, 0)
+
+    await appendFile(
+      join(transcriptDir, 'journal.jsonl'),
+      `${agents
+        .map((agent, index) =>
+          JSON.stringify({ type: 'started', key: `key-${index}`, agentId: agent.id }),
+        )
+        .join('\n')}\n`,
+    )
+    await waitForCondition(
+      () =>
+        events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      3,
+    )
+
+    const starts = events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent')
+    assert.equal(starts.length, 3)
+    assert.deepEqual(
+      starts.map((event) => event.input.prompt).sort(),
+      agents.map((agent) => agent.prompt).sort(),
+    )
+    assert.equal(
+      events.filter(
+        (event) =>
+          event.type === 'tool_result' && String(event.toolUseId).startsWith('workflow-agent:'),
+      ).length,
+      0,
+      'workflow agents should remain visibly running before journal results arrive',
+    )
+
+    await appendFile(
+      join(transcriptDir, 'journal.jsonl'),
+      `${agents
+        .map((agent, index) =>
+          JSON.stringify({
+            type: 'result',
+            key: `key-${index}`,
+            agentId: agent.id,
+            result: {
+              agentId: agent.id,
+              agentName: agent.name,
+              status: 'ok',
+              reply: 'ok',
+              details: 'Observed Claude Code workflow journal result shape',
+            },
+          }),
+        )
+        .join('\n')}\n`,
+    )
+    await waitForCondition(
+      () =>
+        events.filter(
+          (event) =>
+            event.type === 'tool_result' && String(event.toolUseId).startsWith('workflow-agent:'),
+        ).length,
+      3,
+    )
+
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_notification',
+      task_id: 'workflow-task-id',
+      status: 'completed',
+      summary: 'All reviewers completed',
+      usage: { total_tokens: 100, tool_uses: 3, duration_ms: 2500 },
+    })
+    notified = true
+
+    const results = events.filter(
+      (event) =>
+        event.type === 'tool_result' && String(event.toolUseId).startsWith('workflow-agent:'),
+    )
+    assert.equal(results.length, 3)
+    assert.equal(
+      results.every((event) => event.isError === false),
+      true,
+    )
+    assert.equal(
+      results.every((event) => /"reply": "ok"/.test(event.content)),
+      true,
+    )
+    assert.equal(
+      events.some((event) => String(event.toolUseId).startsWith('workflow-task:')),
+      false,
+      'the aggregate workflow card should not replace individual journal agents',
+    )
+    const summaryEvent = events.find((event) => event.type === 'notice')
+    assert.match(summaryEvent?.message ?? '', /All reviewers completed/)
+    assert.match(summaryEvent?.message ?? '', /total_tokens: 100/)
+  } finally {
+    if (!notified) {
+      await handleSystem.call(runtime, pending, {
+        subtype: 'task_notification',
+        task_id: 'workflow-task-id',
+        status: 'stopped',
+        summary: 'test cleanup',
+      })
+    }
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime waits for a slightly delayed workflow journal result', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-delayed-workflow-result-'))
+  const runId = 'wf_delayed_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'dddddddd44444444'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Review delayed module' } })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['delayed-workflow-launch']),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'delayed-workflow-task',
+      tool_use_id: 'delayed-workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'delayed-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'delayed-workflow-task',
+        taskType: 'local_workflow',
+        workflowName: 'delayed-workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'delayed-workflow-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await appendFile(
+      join(transcriptDir, 'journal.jsonl'),
+      `${JSON.stringify({ type: 'started', key: 'delayed-key', agentId })}\n`,
+    )
+    await waitForCondition(
+      () =>
+        events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      1,
+    )
+
+    const delayedWrite = new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        void appendFile(
+          join(transcriptDir, 'journal.jsonl'),
+          `${JSON.stringify({
+            type: 'result',
+            key: 'delayed-key',
+            agentId,
+            result: { status: 'ok', reply: 'ok' },
+          })}\n`,
+        ).then(resolve, reject)
+      }, 700)
+    })
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_notification',
+      task_id: 'delayed-workflow-task',
+      status: 'completed',
+      summary: 'Delayed workflow completed',
+    })
+    await delayedWrite
+
+    const results = events.filter(
+      (event) =>
+        event.type === 'tool_result' && String(event.toolUseId).startsWith('workflow-agent:'),
+    )
+    assert.equal(results.length, 1)
+    assert.equal(results[0].isError, false)
+    assert.match(results[0].content, /"reply": "ok"/)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK parent result does not cap workflow runtime at three seconds', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-parent-result-workflow-'))
+  const runId = 'wf_parent_result_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'fafafafa191919191'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Parent result race prompt' } })}\n`,
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'parent-result-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  let resolved = false
+  const pending = {
+    context: nativeTurnContext({ turnId: 'parent-result-workflow-turn' }),
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['parent-result-workflow-launch']),
+    workflowTranscriptRoots: [root],
+    workflowTasks: new Map(),
+    skippedWorkflowTaskIds: new Set<string>(),
+    structuredBuffer: '',
+    resolved: false,
+    resolve: () => {
+      resolved = true
+    },
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const handleResult = Reflect.get(runtime, 'handleResult')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'parent-result-workflow-task',
+      tool_use_id: 'parent-result-workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'parent-result-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'parent-result-workflow-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'parent-result-workflow-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await waitForCondition(
+      () =>
+        events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      1,
+    )
+
+    const parentResult = handleResult.call(runtime, pending, {
+      subtype: 'success',
+      is_error: false,
+      result: 'Parent turn completed',
+      usage: {},
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 3_200))
+    assert.equal(resolved, false, 'parent turn must remain open while Workflow is still running')
+    assert.equal(
+      events.some((event) => event.type === 'completed'),
+      false,
+      'turn/completed must not be emitted before the Workflow terminal notification',
+    )
+    assert.equal(
+      pending.activeSubagents.has(`workflow-agent:parent-result-workflow-task:${agentId}`),
+      true,
+      'the projected Agent must remain running beyond three seconds',
+    )
+
+    await appendFile(
+      join(transcriptDir, 'journal.jsonl'),
+      `${JSON.stringify({
+        type: 'result',
+        key: 'parent-result-key',
+        agentId,
+        result: { status: 'ok', reply: 'ok' },
+      })}\n`,
+    )
+    await waitForCondition(
+      () =>
+        events.filter(
+          (event) =>
+            event.type === 'tool_result' && String(event.toolUseId).startsWith('workflow-agent:'),
+        ).length,
+      1,
+    )
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_notification',
+      task_id: 'parent-result-workflow-task',
+      status: 'completed',
+      summary: 'Long-running workflow completed',
+    })
+    await parentResult
+
+    const result = events.find(
+      (event) =>
+        event.type === 'tool_result' && String(event.toolUseId).startsWith('workflow-agent:'),
+    )
+    assert.equal(result?.isError, false)
+    assert.equal(resolved, true)
+    assert.ok(
+      events.findIndex((event) => event.type === 'tool_result') <
+        events.findIndex((event) => event.type === 'completed'),
+      'Agent result must be emitted before turn/completed',
+    )
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime waits for the workflow agent prompt file before projecting it', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-delayed-workflow-prompt-'))
+  const runId = 'wf_delayed_prompt_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'dadadada131313131'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'delayed-prompt-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['delayed-prompt-launch']),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'delayed-prompt-task',
+      tool_use_id: 'delayed-prompt-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'delayed-prompt-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'delayed-prompt-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'delayed-prompt-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    assert.equal(
+      events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      0,
+    )
+
+    await writeFile(
+      join(transcriptDir, `agent-${agentId}.jsonl`),
+      `${JSON.stringify({ message: { role: 'user', content: 'Delayed prompt content' } })}\n`,
+    )
+    await waitForCondition(
+      () =>
+        events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      1,
+    )
+    const start = events.find((event) => event.type === 'tool_use' && event.toolName === 'Agent')
+    assert.equal(start.input.prompt, 'Delayed prompt content')
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime attaches a deferred Workflow launch after task_started arrives', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-deferred-workflow-launch-'))
+  const runId = 'wf_deferred_launch_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'dededede171717171'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Deferred launch prompt' } })}\n`,
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'deferred-launch-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['deferred-workflow-launch']),
+    workflowTranscriptRoots: [root],
+    workflowTasks: new Map(),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'deferred-workflow-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'deferred-workflow-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    assert.equal(
+      events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      0,
+    )
+
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'deferred-workflow-task',
+      tool_use_id: 'deferred-workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'deferred-workflow',
+    })
+    await waitForCondition(
+      () =>
+        events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      1,
+    )
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime falls back to aggregate Agent when workflow journal stays empty', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-empty-workflow-journal-'))
+  const runId = 'wf_empty_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(join(transcriptDir, 'journal.jsonl'), '')
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['empty-workflow-launch']),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'empty-workflow-task',
+      tool_use_id: 'empty-workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'empty-workflow',
+      description: 'Workflow with no agent journal entries',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'empty-workflow-task',
+        taskType: 'local_workflow',
+        workflowName: 'empty-workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'empty-workflow-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_notification',
+      task_id: 'empty-workflow-task',
+      status: 'completed',
+      summary: 'Workflow completed without journal agents',
+    })
+
+    const aggregate = events.filter(
+      (event) =>
+        event.toolUseId === 'workflow-task:empty-workflow-task' &&
+        (event.type === 'tool_use' || event.type === 'tool_result'),
+    )
+    assert.equal(aggregate.length, 2)
+    assert.equal(aggregate[0].toolName, 'Agent')
+    assert.equal(aggregate[1].isError, false)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime accepts Workflow launch metadata after the old fallback window', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-late-workflow-launch-'))
+  const runId = 'wf_late_launch_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'acacacac999999999'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Late launch prompt' } })}\n`,
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'late-launch-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['late-workflow-launch']),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'late-workflow-task',
+      tool_use_id: 'late-workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'late-workflow',
+    })
+    await new Promise((resolve) => setTimeout(resolve, 850))
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'late-workflow-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'late-workflow-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    assert.equal(
+      events.filter(
+        (event) =>
+          event.type === 'tool_use' && String(event.toolUseId).startsWith('workflow-agent:'),
+      ).length,
+      1,
+    )
+    assert.equal(
+      events.some((event) => event.toolUseId === 'workflow-task:late-workflow-task'),
+      false,
+    )
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime hides skip_transcript workflow journals', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-hidden-workflow-'))
+  const runId = 'wf_hidden_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'bcbcbcbc101010101'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Hidden workflow prompt' } })}\n`,
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'hidden-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['hidden-workflow-launch']),
+    workflowTranscriptRoots: [root],
+    skippedWorkflowTaskIds: new Set<string>(),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'hidden-workflow-task',
+      tool_use_id: 'hidden-workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'hidden-workflow',
+      skip_transcript: true,
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'hidden-workflow-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'hidden-workflow-launch',
+            content: 'Hidden workflow launched.',
+          },
+        ],
+      },
+    })
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_notification',
+      task_id: 'hidden-workflow-task',
+      status: 'completed',
+      summary: 'Hidden workflow completed',
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    assert.equal(
+      events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      0,
+    )
+    assert.equal(
+      events.some((event) => String(event.toolUseId).startsWith('workflow-task:')),
+      false,
+    )
+    assert.equal(
+      events.some((event) => event.type === 'notice'),
+      false,
+    )
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime ignores workflow-shaped metadata from a non-Workflow tool', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-untrusted-workflow-result-'))
+  const runId = 'wf_untrusted_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'eeeeeeee55555555'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Untrusted prompt' } })}\n`,
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'untrusted-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set<string>(),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'untrusted-workflow-task',
+      tool_use_id: 'ordinary-tool',
+      task_type: 'local_workflow',
+      workflow_name: 'untrusted-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'untrusted-workflow-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'ordinary-tool',
+            content: 'Lookalike workflow metadata',
+          },
+        ],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    assert.equal(
+      events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      0,
+    )
+    assert.equal(pending.workflowToolUseIds.size, 0)
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime rejects Workflow launch metadata bound to a different task', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-mismatched-workflow-task-'))
+  const runId = 'wf_mismatched_task_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'abababab151515151'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Mismatched workflow prompt' } })}\n`,
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'mismatched-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['mismatched-workflow-launch']),
+    workflowTranscriptRoots: [root],
+    workflowTasks: new Map(),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'expected-workflow-task',
+      tool_use_id: 'mismatched-workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'mismatched-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'different-workflow-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'mismatched-workflow-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    assert.equal(
+      events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      0,
+    )
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime rejects ambiguous batched Workflow tool results', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-ambiguous-workflow-result-'))
+  const runId = 'wf_ambiguous_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'edededed888888888'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Ambiguous prompt' } })}\n`,
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'ambiguous-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['workflow-launch']),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'ambiguous-workflow-task',
+      tool_use_id: 'workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'ambiguous-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'ambiguous-workflow-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'workflow-launch',
+            content: 'Workflow launched in background.',
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'ordinary-tool',
+            content: 'Another result in the same SDK message.',
+          },
+        ],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    assert.equal(
+      events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      0,
+    )
+    assert.equal(pending.workflowToolUseIds.size, 0)
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime rejects a symlinked workflow journal file', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-workflow-journal-symlink-'))
+  const runId = 'wf_journal_symlink_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const outsideJournal = join(root, 'outside-journal.jsonl')
+  const agentId = 'abababab77777777'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Journal symlink prompt' } })}\n`,
+  )
+  await writeFile(
+    outsideJournal,
+    `${JSON.stringify({ type: 'started', key: 'outside-journal-key', agentId })}\n`,
+  )
+  await symlink(outsideJournal, join(transcriptDir, 'journal.jsonl'), 'file')
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['journal-symlink-launch']),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'journal-symlink-task',
+      tool_use_id: 'journal-symlink-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'journal-symlink-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'journal-symlink-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'journal-symlink-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    assert.equal(
+      events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      0,
+    )
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_notification',
+      task_id: 'journal-symlink-task',
+      status: 'completed',
+      summary: 'Journal symlink workflow completed',
+    })
+    assert.equal(
+      events.filter((event) => event.toolUseId === 'workflow-task:journal-symlink-task').length,
+      2,
+    )
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime rejects workflow transcript symlinks that escape the trusted root', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-workflow-symlink-'))
+  const trustedRoot = join(root, 'trusted')
+  const runId = 'wf_symlink_run'
+  const transcriptDir = join(trustedRoot, 'projects', 'project', 'subagents', 'workflows', runId)
+  const outsideDir = join(root, 'outside', 'subagents', 'workflows', runId)
+  const agentId = 'ffffffff66666666'
+  await mkdir(join(transcriptDir, '..'), { recursive: true })
+  await mkdir(outsideDir, { recursive: true })
+  await writeFile(
+    join(outsideDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Outside prompt' } })}\n`,
+  )
+  await writeFile(
+    join(outsideDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'outside-key', agentId })}\n`,
+  )
+  await symlink(outsideDir, transcriptDir, 'dir')
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['trusted-workflow-launch']),
+    workflowTranscriptRoots: [trustedRoot],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'trusted-workflow-task',
+      tool_use_id: 'trusted-workflow-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'symlink-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'trusted-workflow-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'trusted-workflow-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    assert.equal(
+      events.filter((event) => event.type === 'tool_use' && event.toolName === 'Agent').length,
+      0,
+    )
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_notification',
+      task_id: 'trusted-workflow-task',
+      status: 'completed',
+      summary: 'Symlink workflow completed',
+    })
+    assert.equal(
+      events.filter((event) => event.toolUseId === 'workflow-task:trusted-workflow-task').length,
+      2,
+    )
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime rejects a workflow directory replaced after canonical validation', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-workflow-directory-swap-'))
+  const runId = 'wf_directory_swap_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const archivedDir = join(root, 'archived-transcript')
+  const outsideDir = join(root, 'outside-replacement')
+  const agentId = 'cdcdcdcd121212121'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(join(transcriptDir, 'journal.jsonl'), '')
+  await mkdir(outsideDir, { recursive: true })
+  await writeFile(
+    join(outsideDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Replacement prompt' } })}\n`,
+  )
+  await writeFile(
+    join(outsideDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'replacement-key', agentId })}\n`,
+  )
+
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set(['directory-swap-launch']),
+    workflowTranscriptRoots: [root],
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+  const handleUser = Reflect.get(runtime, 'handleUser')
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  try {
+    await handleSystem.call(runtime, pending, {
+      subtype: 'task_started',
+      task_id: 'directory-swap-task',
+      tool_use_id: 'directory-swap-launch',
+      task_type: 'local_workflow',
+      workflow_name: 'directory-swap-workflow',
+    })
+    await handleUser.call(runtime, pending, {
+      type: 'user',
+      tool_use_result: {
+        status: 'async_launched',
+        taskId: 'directory-swap-task',
+        taskType: 'local_workflow',
+        runId,
+        transcriptDir,
+      },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'directory-swap-launch',
+            content: 'Workflow launched in background.',
+          },
+        ],
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    await rename(transcriptDir, archivedDir)
+    await symlink(outsideDir, transcriptDir, 'dir')
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    assert.equal(
+      events.filter(
+        (event) =>
+          event.type === 'tool_use' && String(event.toolUseId).startsWith('workflow-agent:'),
+      ).length,
+      0,
+    )
+  } finally {
+    await stopWorkflowTasks.call(runtime, pending)
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('native SDK runtime falls back to one Agent lifecycle without workflow journal metadata', async () => {
   const runtime = new NativeClaudeRuntime()
   const events: any[] = []
   const pending = {
@@ -236,6 +1491,274 @@ test('native SDK runtime maps local workflow task events to one Agent lifecycle'
   assert.equal(events[1].toolUseId, 'workflow-task:wf-123')
   assert.match(events[1].content, /total_tokens: 100/)
   assert.equal(events[1].isError, false)
+})
+
+test('native SDK runtime ignores non-workflow task notifications', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowTasks: new Map(),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+
+  await handleSystem.call(runtime, pending, {
+    subtype: 'task_notification',
+    task_id: 'ordinary-background-task',
+    status: 'completed',
+    summary: 'Ordinary task completed',
+  })
+
+  assert.deepEqual(events, [])
+})
+
+test('native SDK runtime closes lagged workflow agents using the terminal task status', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const taskId = 'lagged-workflow-task'
+  const agentId = 'efefefef141414141'
+  const agentToolUseId = `workflow-agent:${taskId}:${agentId}`
+  const pending = {
+    activeSubagents: new Set<string>([agentToolUseId]),
+    completedWorkflowTasks: new Set<string>(),
+    workflowTasks: new Map([
+      [
+        taskId,
+        {
+          taskId,
+          workflowName: 'lagged-workflow',
+          description: '',
+          prompt: '',
+          monitor: {
+            startedCount: 0,
+            flush: async () => undefined,
+            drain: async () => undefined,
+            stop: async () => undefined,
+            activeAgentIds: () => [],
+          },
+          aggregateStarted: false,
+          terminal: false,
+        },
+      ],
+    ]),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+
+  await handleSystem.call(runtime, pending, {
+    subtype: 'task_notification',
+    task_id: taskId,
+    status: 'completed',
+    summary: 'Lagged workflow completed',
+  })
+
+  const result = events.find(
+    (event) => event.type === 'tool_result' && event.toolUseId === agentToolUseId,
+  )
+  assert.equal(result?.isError, false)
+  assert.equal(pending.activeSubagents.has(agentToolUseId), false)
+  assert.equal(
+    events.some((event) => event.toolUseId === `workflow-task:${taskId}`),
+    false,
+  )
+})
+
+test('native SDK runtime bounds terminal workflow monitor flushes', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const taskId = 'blocked-flush-workflow-task'
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowTasks: new Map([
+      [
+        taskId,
+        {
+          taskId,
+          toolUseId: 'blocked-flush-workflow-launch',
+          workflowName: 'blocked-flush-workflow',
+          description: '',
+          prompt: '',
+          monitor: {
+            startedCount: 0,
+            flush: async () => await new Promise<void>(() => {}),
+            drain: async () => undefined,
+            stop: async () => undefined,
+            activeAgentIds: () => [],
+          },
+          aggregateStarted: false,
+          terminal: false,
+        },
+      ],
+    ]),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+
+  const completed = await Promise.race([
+    handleSystem
+      .call(runtime, pending, {
+        subtype: 'task_notification',
+        task_id: taskId,
+        status: 'completed',
+        summary: 'Blocked flush workflow completed',
+      })
+      .then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 1_000)),
+  ])
+
+  assert.equal(completed, true)
+  assert.equal(events.filter((event) => event.toolUseId === `workflow-task:${taskId}`).length, 2)
+})
+
+test('native SDK runtime closes projected workflow agents when workflow monitoring stops', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const taskId = 'stopped-workflow-task'
+  const agentId = 'efefefef181818181'
+  const agentToolUseId = `workflow-agent:${taskId}:${agentId}`
+  const pending = {
+    activeSubagents: new Set<string>([agentToolUseId]),
+    completedWorkflowTasks: new Set<string>(),
+    workflowTasks: new Map([
+      [
+        taskId,
+        {
+          taskId,
+          toolUseId: 'stopped-workflow-launch',
+          workflowName: 'stopped-workflow',
+          description: '',
+          prompt: '',
+          monitor: {
+            startedCount: 0,
+            flush: async () => undefined,
+            drain: async () => undefined,
+            stop: async () => undefined,
+            activeAgentIds: () => [],
+          },
+          aggregateStarted: false,
+          terminal: false,
+        },
+      ],
+    ]),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const stopWorkflowTasks = Reflect.get(runtime, 'stopWorkflowTasks')
+
+  await stopWorkflowTasks.call(runtime, pending)
+
+  const result = events.find(
+    (event) => event.type === 'tool_result' && event.toolUseId === agentToolUseId,
+  )
+  assert.equal(result?.isError, true)
+  assert.equal(pending.activeSubagents.has(agentToolUseId), false)
+})
+
+test('workflow journal monitor reads the final assistant transcript when result is empty', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-empty-workflow-result-'))
+  const runId = 'wf_empty_result_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'abababab202020202'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    [
+      JSON.stringify({ message: { role: 'user', content: 'Reply ok' } }),
+      JSON.stringify({
+        message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      }),
+      '',
+    ].join('\n'),
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    [
+      JSON.stringify({ type: 'started', key: 'empty-result-key', agentId }),
+      JSON.stringify({ type: 'result', key: 'empty-result-key', agentId, result: '' }),
+      '',
+    ].join('\n'),
+  )
+
+  const results: Array<{ content: string; isError: boolean }> = []
+  const monitor = new WorkflowJournalMonitor({
+    launch: {
+      taskId: 'empty-result-task',
+      workflowName: 'empty-result-workflow',
+      runId,
+      transcriptDir,
+      transcriptRoot: root,
+      summary: '',
+    },
+    onStarted: async () => {},
+    onResult: async (result) => {
+      results.push(result)
+    },
+  })
+
+  try {
+    await monitor.flush()
+    assert.equal(results.length, 1)
+    assert.equal(results[0]?.content, `ok\nagentId: ${agentId}`)
+    assert.equal(results[0]?.isError, false)
+  } finally {
+    await monitor.stop()
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('workflow journal monitor does not commit started bookkeeping after stop', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'claude-codex-stopped-workflow-monitor-'))
+  const runId = 'wf_stopped_monitor_run'
+  const transcriptDir = join(root, 'projects', 'project', 'subagents', 'workflows', runId)
+  const agentId = 'cdcdcdcd161616161'
+  await mkdir(transcriptDir, { recursive: true })
+  await writeFile(
+    join(transcriptDir, `agent-${agentId}.jsonl`),
+    `${JSON.stringify({ message: { role: 'user', content: 'Stop race prompt' } })}\n`,
+  )
+  await writeFile(
+    join(transcriptDir, 'journal.jsonl'),
+    `${JSON.stringify({ type: 'started', key: 'stop-race-key', agentId })}\n`,
+  )
+
+  let enterStarted!: () => void
+  let releaseStarted!: () => void
+  const entered = new Promise<void>((resolve) => {
+    enterStarted = resolve
+  })
+  const release = new Promise<void>((resolve) => {
+    releaseStarted = resolve
+  })
+  const monitor = new WorkflowJournalMonitor({
+    launch: {
+      taskId: 'stopped-monitor-task',
+      workflowName: 'stopped-monitor-workflow',
+      runId,
+      transcriptDir,
+      transcriptRoot: root,
+      summary: '',
+    },
+    onStarted: async () => {
+      enterStarted()
+      await release
+    },
+    onResult: async () => {},
+  })
+
+  try {
+    const flush = monitor.flush()
+    await entered
+    await monitor.stop(10)
+    releaseStarted()
+    await flush
+    assert.equal(monitor.startedCount, 0)
+  } finally {
+    releaseStarted()
+    await monitor.stop()
+    await rm(root, { recursive: true, force: true })
+  }
 })
 
 test('native SDK permission allow result carries original input for SDK validation', async () => {
@@ -1002,4 +2525,13 @@ function processIsAlive(pid: number): boolean {
   } catch {
     return false
   }
+}
+
+async function waitForCondition(read: () => number, expected: number): Promise<void> {
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    if (read() === expected) return
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  assert.equal(read(), expected)
 }

--- a/test/runtime-config.test.mts
+++ b/test/runtime-config.test.mts
@@ -1657,6 +1657,7 @@ test('native SDK runtime closes lagged workflow agents using the terminal task s
 test('native SDK runtime bounds terminal workflow monitor flushes', async () => {
   const runtime = new NativeClaudeRuntime()
   const events: any[] = []
+  let stopCalls = 0
   const taskId = 'blocked-flush-workflow-task'
   const pending = {
     activeSubagents: new Set<string>(),
@@ -1674,7 +1675,9 @@ test('native SDK runtime bounds terminal workflow monitor flushes', async () => 
             startedCount: 0,
             flush: async () => await new Promise<void>(() => {}),
             drain: async () => undefined,
-            stop: async () => undefined,
+            stop: async () => {
+              stopCalls += 1
+            },
             activeAgentIds: () => [],
           },
           aggregateStarted: false,
@@ -1700,6 +1703,7 @@ test('native SDK runtime bounds terminal workflow monitor flushes', async () => 
 
   assert.equal(completed, true)
   assert.equal(events.filter((event) => event.toolUseId === `workflow-task:${taskId}`).length, 2)
+  assert.equal(stopCalls, 1, 'terminal fallback must stop its journal monitor before aggregation')
 })
 
 test('native SDK runtime closes projected workflow agents when workflow monitoring stops', async () => {

--- a/test/runtime-config.test.mts
+++ b/test/runtime-config.test.mts
@@ -13,6 +13,33 @@ import {
 } from '../src/http-agent-runtime.mjs'
 import { NativeClaudeRuntime, sdkResumeSessionId } from '../src/native-runtime.mjs'
 import { resolveRuntimeConfig } from '../src/runtime-config.mjs'
+import type { RuntimeTurnContext } from '../src/types.mjs'
+import { parseWorkflowCommand, workflowRuntimePrompt } from '../src/workflow-command.mjs'
+
+function nativeTurnContext(overrides: Partial<RuntimeTurnContext> = {}): RuntimeTurnContext {
+  return {
+    threadId: 'thread',
+    turnId: 'turn',
+    prompt: 'hello',
+    cwd: process.cwd(),
+    runtimeType: null,
+    model: null,
+    effort: null,
+    claudeSessionId: null,
+    forkSession: false,
+    mcpServers: null,
+    allowedTools: null,
+    addDirs: [],
+    enableFileCheckpointing: false,
+    outputFormat: null,
+    approvalPolicy: null,
+    sandboxMode: null,
+    systemPromptAddendum: null,
+    planMode: false,
+    imageInputs: [],
+    ...overrides,
+  }
+}
 
 test('runtime config keeps legacy defaults and accepts explicit backends', () => {
   assert.equal(resolveRuntimeConfig({}).type, 'agent-sdk-sidecar')
@@ -58,6 +85,114 @@ test('native SDK runtime ignores bridge session markers when resuming SDK turns'
   assert.equal(sdkResumeSessionId('agentapi:http://127.0.0.1:3284'), null)
   assert.equal(sdkResumeSessionId('claude-p:session'), null)
   assert.equal(sdkResumeSessionId('sdk-session'), 'sdk-session')
+})
+
+test('native SDK runtime maps manual /workflows prompts to the human workflow trigger', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const context = nativeTurnContext({ prompt: '/workflows open three subagents, reply ok' })
+  const buildPromptIterable = Reflect.get(runtime, 'buildPromptIterable')
+  const messages: any[] = []
+  for await (const message of buildPromptIterable.call(runtime, context)) messages.push(message)
+
+  assert.equal(
+    messages[0].message.content,
+    [
+      'ultracode: open three subagents, reply ok',
+      '',
+      'Keep the launched workflow attached to this turn: wait for every workflow task to finish before returning the final response.',
+    ].join('\n'),
+  )
+  assert.deepEqual(messages[0].origin, { kind: 'human' })
+
+  const buildOptions = Reflect.get(runtime, 'buildOptions')
+  const options = buildOptions.call(runtime, {}, context, new AbortController())
+  assert.deepEqual(options.settings, {
+    enableWorkflows: true,
+    workflowKeywordTriggerEnabled: true,
+  })
+  assert.equal(options.permissionMode, 'default')
+  assert.equal(typeof options.canUseTool, 'function')
+})
+
+test('workflow command parser keeps list and run semantics distinct', () => {
+  assert.deepEqual(parseWorkflowCommand('/workflows'), { type: 'list' })
+  assert.deepEqual(parseWorkflowCommand('  /workflows inspect the adapter'), {
+    type: 'run',
+    prompt: 'inspect the adapter',
+  })
+  assert.equal(parseWorkflowCommand('/workflowsx inspect'), null)
+  assert.equal(workflowRuntimePrompt('/workflows'), '/workflows')
+
+  const runtime = new NativeClaudeRuntime()
+  const buildOptions = Reflect.get(runtime, 'buildOptions')
+  const options = buildOptions.call(
+    runtime,
+    {},
+    nativeTurnContext({ prompt: '/workflows' }),
+    new AbortController(),
+  )
+  assert.equal(options.settings, undefined)
+})
+
+test('manual workflow normalization preserves attached image blocks', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const buildPromptIterable = Reflect.get(runtime, 'buildPromptIterable')
+  const context = nativeTurnContext({
+    prompt: '/workflows inspect this image',
+    imageInputs: [
+      {
+        kind: 'url',
+        mediaType: 'image/png',
+        data: 'https://example.com/image.png',
+        displayPath: 'https://example.com/image.png',
+      },
+    ],
+  })
+  const messages: any[] = []
+  for await (const message of buildPromptIterable.call(runtime, context)) messages.push(message)
+  assert.match(messages[0].message.content[0].text, /^ultracode: inspect this image/)
+  assert.deepEqual(messages[0].message.content[1], {
+    type: 'image',
+    source: { type: 'url', url: 'https://example.com/image.png' },
+  })
+})
+
+test('native SDK runtime maps local workflow task events to one Agent lifecycle', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+
+  await handleSystem.call(runtime, pending, {
+    subtype: 'task_started',
+    task_id: 'wf-123',
+    task_type: 'local_workflow',
+    workflow_name: 'parallel-review',
+    description: 'Review three modules',
+  })
+  await handleSystem.call(runtime, pending, {
+    subtype: 'task_notification',
+    task_id: 'wf-123',
+    status: 'completed',
+    summary: 'All reviewers completed',
+    usage: { total_tokens: 100, tool_uses: 3, duration_ms: 2500 },
+  })
+  await handleSystem.call(runtime, pending, {
+    subtype: 'task_started',
+    task_id: 'wf-123',
+    task_type: 'local_workflow',
+  })
+
+  assert.equal(events.length, 2)
+  assert.equal(events[0].toolName, 'Agent')
+  assert.equal(events[0].input.subagent_type, 'workflow')
+  assert.equal(events[1].toolUseId, 'workflow-task:wf-123')
+  assert.match(events[1].content, /total_tokens: 100/)
+  assert.equal(events[1].isError, false)
 })
 
 test('native SDK permission allow result carries original input for SDK validation', async () => {

--- a/test/runtime-config.test.mts
+++ b/test/runtime-config.test.mts
@@ -885,6 +885,45 @@ test('native SDK runtime settles an out-of-order workflow task notification', as
   assert.match(aggregate[1].content, /Workflow completed after reconnect/)
 })
 
+test('native SDK runtime accepts the declared SDK task_notification shape', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    // The real SDK notification may omit task_type/workflow_name. The
+    // tool_use_id is the stable correlation key when the Workflow launch is
+    // still pending.
+    workflowToolUseIds: new Set(['sdk-workflow-launch']),
+    workflowLaunches: new Map(),
+    workflowTranscriptRoots: [process.cwd()],
+    workflowTasks: new Map(),
+    skippedWorkflowTaskIds: new Set<string>(),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+
+  await handleSystem.call(runtime, pending, {
+    subtype: 'task_notification',
+    task_id: 'sdk-shaped-workflow-task',
+    tool_use_id: 'sdk-workflow-launch',
+    status: 'completed',
+    output_file: '/tmp/claude-workflow-output.jsonl',
+    summary: 'SDK-shaped workflow completed',
+    usage: { total_tokens: 12, tool_uses: 1, duration_ms: 20 },
+  })
+
+  const aggregate = events.filter(
+    (event) =>
+      event.toolUseId === 'workflow-task:sdk-shaped-workflow-task' &&
+      (event.type === 'tool_use' || event.type === 'tool_result'),
+  )
+  assert.equal(aggregate.length, 2)
+  assert.equal(aggregate[0].toolName, 'Agent')
+  assert.equal(aggregate[1].isError, false)
+  assert.match(aggregate[1].content, /SDK-shaped workflow completed/)
+})
+
 test('native SDK runtime accepts Workflow launch metadata after the old fallback window', async () => {
   const root = await mkdtemp(join(tmpdir(), 'claude-codex-late-workflow-launch-'))
   const runId = 'wf_late_launch_run'
@@ -1323,7 +1362,15 @@ test('native SDK runtime rejects a symlinked workflow journal file', async () =>
     })
     assert.equal(
       events.filter((event) => event.toolUseId === 'workflow-task:journal-symlink-task').length,
-      2,
+      0,
+      'a rejected journal must not be revived as a successful aggregate Agent',
+    )
+    assert.match(String((pending as any).workflowFailure ?? ''), /monitoring failed/i)
+    assert.equal(
+      events.some(
+        (event) => event.type === 'notice' && /monitoring failed/i.test(String(event.message)),
+      ),
+      true,
     )
   } finally {
     await stopWorkflowTasks.call(runtime, pending)
@@ -1404,7 +1451,15 @@ test('native SDK runtime rejects workflow transcript symlinks that escape the tr
     })
     assert.equal(
       events.filter((event) => event.toolUseId === 'workflow-task:trusted-workflow-task').length,
-      2,
+      0,
+      'an escaped transcript must not be revived as a successful aggregate Agent',
+    )
+    assert.match(String((pending as any).workflowFailure ?? ''), /monitoring failed/i)
+    assert.equal(
+      events.some(
+        (event) => event.type === 'notice' && /monitoring failed/i.test(String(event.message)),
+      ),
+      true,
     )
   } finally {
     await stopWorkflowTasks.call(runtime, pending)

--- a/test/runtime-config.test.mts
+++ b/test/runtime-config.test.mts
@@ -851,6 +851,40 @@ test('native SDK runtime falls back to aggregate Agent when workflow journal sta
   }
 })
 
+test('native SDK runtime settles an out-of-order workflow task notification', async () => {
+  const runtime = new NativeClaudeRuntime()
+  const events: any[] = []
+  const pending = {
+    activeSubagents: new Set<string>(),
+    completedWorkflowTasks: new Set<string>(),
+    workflowToolUseIds: new Set<string>(),
+    workflowTranscriptRoots: [process.cwd()],
+    workflowTasks: new Map(),
+    handlers: { onEvent: async (event: unknown) => events.push(event) },
+  }
+  const handleSystem = Reflect.get(runtime, 'handleSystem')
+
+  await handleSystem.call(runtime, pending, {
+    // The SDK may batch or reorder these system messages after a reconnect.
+    // There is no preceding task_started marker in this case.
+    subtype: 'task_notification',
+    task_id: 'out-of-order-workflow-task',
+    status: 'completed',
+    workflow_name: 'out-of-order-workflow',
+    summary: 'Workflow completed after reconnect',
+  })
+
+  const aggregate = events.filter(
+    (event) =>
+      event.toolUseId === 'workflow-task:out-of-order-workflow-task' &&
+      (event.type === 'tool_use' || event.type === 'tool_result'),
+  )
+  assert.equal(aggregate.length, 2)
+  assert.equal(aggregate[0].toolName, 'Agent')
+  assert.equal(aggregate[1].isError, false)
+  assert.match(aggregate[1].content, /Workflow completed after reconnect/)
+})
+
 test('native SDK runtime accepts Workflow launch metadata after the old fallback window', async () => {
   const root = await mkdtemp(join(tmpdir(), 'claude-codex-late-workflow-launch-'))
   const runId = 'wf_late_launch_run'

--- a/test/runtime-config.test.mts
+++ b/test/runtime-config.test.mts
@@ -89,7 +89,11 @@ test('native SDK runtime ignores bridge session markers when resuming SDK turns'
 
 test('native SDK runtime maps manual /workflows prompts to the human workflow trigger', async () => {
   const runtime = new NativeClaudeRuntime()
-  const context = nativeTurnContext({ prompt: '/workflows open three subagents, reply ok' })
+  const context = nativeTurnContext({
+    prompt: '/workflows open three subagents, reply ok',
+    approvalPolicy: 'never',
+    sandboxMode: 'danger-full-access',
+  })
   const buildPromptIterable = Reflect.get(runtime, 'buildPromptIterable')
   const messages: any[] = []
   for await (const message of buildPromptIterable.call(runtime, context)) messages.push(message)
@@ -111,7 +115,46 @@ test('native SDK runtime maps manual /workflows prompts to the human workflow tr
     workflowKeywordTriggerEnabled: true,
   })
   assert.equal(options.permissionMode, 'default')
+  assert.equal(options.allowDangerouslySkipPermissions, undefined)
   assert.equal(typeof options.canUseTool, 'function')
+  const turns = Reflect.get(runtime, 'turns') as Map<string, unknown>
+  turns.set(context.turnId, { handlers: {} })
+  try {
+    assert.deepEqual(
+      await options.canUseTool(
+        'Bash',
+        { command: 'true' },
+        {
+          toolUseID: 'tool',
+          signal: new AbortController().signal,
+        },
+      ),
+      { behavior: 'allow' },
+    )
+  } finally {
+    turns.delete(context.turnId)
+  }
+})
+
+test('explicit native SDK bypass includes the required dangerous opt-in flag', () => {
+  const previous = process.env.CLAUDE_CODEX_PERMISSION_MODE
+  process.env.CLAUDE_CODEX_PERMISSION_MODE = 'bypassPermissions'
+  try {
+    const runtime = new NativeClaudeRuntime()
+    const buildOptions = Reflect.get(runtime, 'buildOptions')
+    const options = buildOptions.call(
+      runtime,
+      {},
+      nativeTurnContext({ prompt: '/workflows inspect permissions' }),
+      new AbortController(),
+    )
+    assert.equal(options.permissionMode, 'bypassPermissions')
+    assert.equal(options.allowDangerouslySkipPermissions, true)
+    assert.equal(options.canUseTool, undefined)
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CODEX_PERMISSION_MODE
+    else process.env.CLAUDE_CODEX_PERMISSION_MODE = previous
+  }
 })
 
 test('workflow command parser keeps list and run semantics distinct', () => {


### PR DESCRIPTION
## Summary

- map manual `/workflows <task>` input to the native Claude Agent SDK `ultracode:` workflow trigger while keeping bare `/workflows` as a local run listing
- expose workflow workers through Codex-native `spawnAgent -> wait` lifecycle events and persisted, reviewable Subagent threads; retain `closeAgent` only for failed/orphaned legacy cleanup
- hydrate Subagent Prompt/Response on Codex cc metadata reads (`thread/read` with `includeTurns:false`) without changing ordinary thread semantics
- preserve zero-prompt Codex Full Access through the existing `canUseTool` bridge without Relay's unsupported unsandboxed dangerous-bypass mode
- harden subagent cleanup across interrupt, reconnect, runtime settlement, and final-diff races

## Compatibility boundary

This extends the existing profile shim -> TypeScript App Server -> Claude Agent SDK -> Codex v2 RPC architecture. It does not add a second service, UI, or state store. Workflow bridging applies only to the native Claude Agent SDK backend.

`/workflows` and `ultracode` are related but not identical: the adapter treats `/workflows` as the user-facing command facade and uses `ultracode:` only for the run form.

## Test plan

- `.21` remote `npm run build`
- focused final Subagent lifecycle and `/workflows` tests: 4/4 passed
- workflow/subagent/permission/watchdog suite: 56/56 passed
- Codex cc legacy path: successful children finish at `wait/completed`; no synthetic success `closeAgent`
- Subagent `thread/read(includeTurns:false)` returns completed Prompt/Response
- ordinary parent `thread/read(includeTurns:false)` remains metadata-only
- `git diff --check` clean
- installed Codex cc profile accepted the workflow test without manual permission setup or stuck Subagent loading

Known repository-wide Biome diagnostics are pre-existing outside this patch.
